### PR TITLE
Fixed LinkedIn Cloud Community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Name | Comments
 :------|:------:
 [Reddit DevOps](https://www.reddit.com/r/devops) | Reddit DevOps Community 
 [Linkedin DevOps](https://www.linkedin.com/groups/2825397) | Linkedin DevOps Community
-[Linkedin Cloud ](https://www.linkedin.com/groups/9502832) | Linkedin DevOps & Cloud Community
+[Linkedin Cloud ](https://www.linkedin.com/groups/9510015) | Linkedin DevOps & Cloud Community
 
 ## DevOps Tooling
 


### PR DESCRIPTION
This PR closes #25 

### Changes
- `LinkedIn cloud` community link fixed in **community** section in the **README.md**. 