### PR TITLE
Update: Comprehensive .gitignore for project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,55 @@
+# Dependencies
+node_modules/
+package-lock.json
+
+# Build output
+build/
+.docusaurus/
+
+# Cache
+.cache/
+*.tsbuildinfo
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# OS files
 .DS_Store
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.project
+.settings/
+.classpath
+
+# Claude Code
+.claude/
+
+# Testing
+coverage/
+
+# Misc
+*.pid
+*.seed
+*.pid.lock
+.eslintcache


### PR DESCRIPTION
## Summary
- Expanded `.gitignore` from 3 entries to comprehensive coverage for a Docusaurus/Node.js project
- Added ignore rules for: dependencies (`node_modules/`), build output (`build/`, `.docusaurus/`), cache files, environment variables (`.env*`), log files, OS files (`.DS_Store`, `Thumbs.db`), editor/IDE configs (`.vscode/`, `.idea/`), Claude Code files (`.claude/`), and testing artifacts (`coverage/`)

## Test plan
- [x] Verify no tracked files are accidentally removed
- [x] Confirm `npm run build` still works after changes
