### PR TITLE
Add: Captain's Journey page with Linux theme

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -87,6 +87,7 @@ const config: Config = {
           position: 'left',
           label: 'Cloud Providers',
         },
+        {to: '/journey', label: "Captain's Journey", position: 'left'},
         {to: '/contribute', label: 'Contribute', position: 'left'},
         {
           href: 'https://buymeacoffee.com/nomadicmehul',
@@ -130,6 +131,7 @@ const config: Config = {
         {
           title: 'Community',
           items: [
+            {label: "Captain's Journey", to: '/journey'},
             {label: 'GitHub', href: 'https://github.com/nomadicmehul/CloudCaptain'},
             {label: 'Twitter', href: 'https://twitter.com/nomadicmehul'},
             {label: 'Contributing Guide', to: '/contribute'},

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -539,6 +539,7 @@ div[class*='announcementBar'] { font-weight: 600; font-size: 0.85rem; letter-spa
 }
 .captain-image-wrapper {
   flex-shrink: 0; position: relative;
+  padding-bottom: 3rem;
 }
 /* Rotating gradient ring */
 .captain-image-glow {
@@ -566,7 +567,7 @@ div[class*='announcementBar'] { font-weight: 600; font-size: 0.85rem; letter-spa
   box-shadow: 0 25px 70px rgba(0,0,0,0.5), 0 0 60px rgba(56,189,248,0.15);
 }
 .captain-badge-tag {
-  position: absolute; bottom: -8px; left: 50%; transform: translateX(-50%);
+  position: absolute; bottom: 22px; left: 50%; transform: translateX(-50%);
   background: linear-gradient(135deg, #1E9BD7, #06B6D4);
   color: white; font-size: 0.75rem; font-weight: 700;
   padding: 0.4rem 1.3rem; border-radius: 20px;
@@ -1241,4 +1242,368 @@ div[class*='announcementBar'] { font-weight: 600; font-size: 0.85rem; letter-spa
 @media (max-width: 600px) {
   .career-hero { padding: 3rem 1.25rem; }
   .career-hero__title { font-size: 2.2rem; }
+}
+
+/* ══════════════════════════════════════════════
+   JOURNEY PAGE — Linux & Open Source Flavored
+   ══════════════════════════════════════════════ */
+
+/* ─── Journey Hero ─── */
+.journey-hero {
+  position: relative;
+  padding: 6rem 0 4rem;
+  overflow: hidden;
+  background: linear-gradient(160deg, #0A1628 0%, #0F2027 30%, #0A1628 60%, #162447 100%);
+}
+.journey-hero-bg {
+  position: absolute; inset: 0;
+  background-image:
+    radial-gradient(circle at 20% 50%, rgba(16, 185, 129, 0.08) 0%, transparent 50%),
+    radial-gradient(circle at 80% 30%, rgba(56, 189, 248, 0.06) 0%, transparent 50%);
+}
+.journey-matrix-rain {
+  position: absolute; inset: 0; opacity: 0.03;
+  background-image: repeating-linear-gradient(
+    0deg, transparent, transparent 2px,
+    rgba(16, 185, 129, 0.4) 2px, rgba(16, 185, 129, 0.4) 4px
+  );
+  background-size: 20px 20px;
+  animation: matrixScroll 20s linear infinite;
+}
+@keyframes matrixScroll {
+  from { background-position: 0 0; }
+  to { background-position: 0 400px; }
+}
+.journey-hero-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3rem;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+.journey-hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #10B981;
+  margin-bottom: 1.25rem;
+  letter-spacing: 0.03em;
+}
+.journey-penguin { font-size: 1.1rem; }
+.journey-hero-title {
+  font-size: 3.5rem;
+  font-weight: 900;
+  line-height: 1.1;
+  color: #fff;
+  margin-bottom: 1.25rem;
+}
+.journey-prompt {
+  color: #10B981;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+}
+.journey-hero-accent {
+  background: linear-gradient(135deg, #10B981 0%, #38BDF8 50%, #06B6D4 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.journey-hero-subtitle {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.7);
+  max-width: 520px;
+  margin-bottom: 1.75rem;
+}
+.journey-hero-subtitle code {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10B981;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9em;
+}
+.journey-hero-cta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+/* ─── Journey Terminal ─── */
+.journey-terminal {
+  background: rgba(10, 22, 40, 0.95);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 0 40px rgba(16, 185, 129, 0.08), 0 20px 60px rgba(0, 0, 0, 0.4);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.82rem;
+  max-width: 520px;
+}
+.journey-terminal .terminal__body {
+  padding: 1rem 1.25rem 1.25rem;
+  min-height: 280px;
+}
+.journey-terminal .terminal__prompt { color: #10B981 !important; }
+.journey-terminal .terminal__cmd { color: #38BDF8; }
+.terminal__spacer { height: 0.5rem; }
+.terminal__config-key { color: #F59E0B; font-weight: 500; }
+.terminal__config-eq { color: rgba(255, 255, 255, 0.4); margin: 0 0.15rem; }
+.terminal__config-val { color: #10B981; }
+.terminal__config-line { padding-left: 0.25rem; }
+.terminal__comment { color: rgba(255, 255, 255, 0.35); font-style: italic; }
+.terminal__string { color: #10B981; }
+
+/* ─── Journey Stats ─── */
+.journey-stats-section {
+  background: linear-gradient(180deg, #0A1628 0%, #0F1D32 100%);
+  padding: 3rem 0;
+  border-top: 1px solid rgba(16, 185, 129, 0.08);
+  border-bottom: 1px solid rgba(16, 185, 129, 0.08);
+}
+.journey-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1.5rem;
+}
+.journey-stat-card {
+  text-align: center;
+  padding: 1.5rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(16, 185, 129, 0.04);
+  border: 1px solid rgba(16, 185, 129, 0.1);
+  transition: all 0.3s ease;
+}
+.journey-stat-card:hover {
+  border-color: rgba(16, 185, 129, 0.3);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(16, 185, 129, 0.1);
+}
+.journey-stat-icon { font-size: 1.5rem; margin-bottom: 0.5rem; }
+.journey-stat-number {
+  font-size: 1.75rem; font-weight: 800; color: #10B981;
+  font-family: 'JetBrains Mono', monospace;
+}
+.journey-stat-label {
+  font-size: 0.75rem; color: rgba(255, 255, 255, 0.5);
+  text-transform: uppercase; letter-spacing: 0.05em;
+  margin-top: 0.25rem; font-weight: 600;
+}
+
+/* ─── Journey Sections ─── */
+.journey-section { padding: 5rem 0; background: #0A1628; }
+.journey-section--badges { background: linear-gradient(180deg, #0F1D32 0%, #0A1628 100%); }
+.journey-section--timeline { background: #0A1628; position: relative; }
+.journey-section--projects { background: linear-gradient(180deg, #0A1628 0%, #0F1D32 100%); }
+.journey-section--philosophy { background: #0A1628; padding: 4rem 0; }
+.journey-section--cta { background: linear-gradient(180deg, #0F1D32 0%, #0A1628 100%); padding: 5rem 0 6rem; }
+.journey-section .section__title {
+  font-size: 2.2rem; font-weight: 800; color: #fff;
+  text-align: center; margin-bottom: 0.75rem;
+}
+.journey-section .section__title .journey-prompt { font-size: 0.9em; }
+
+/* ─── Badges Grid ─── */
+.journey-badges-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+.journey-badge-card {
+  text-align: center; padding: 2rem 1.5rem; border-radius: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transition: all 0.35s ease; position: relative; overflow: hidden;
+}
+.journey-badge-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0;
+  height: 3px; background: var(--badge-accent, #10B981);
+  opacity: 0; transition: opacity 0.3s ease;
+}
+.journey-badge-card:hover {
+  border-color: var(--badge-accent, #10B981);
+  transform: translateY(-4px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
+}
+.journey-badge-card:hover::before { opacity: 1; }
+.journey-badge-icon { font-size: 2.5rem; margin-bottom: 0.75rem; }
+.journey-badge-title { font-size: 1.1rem; font-weight: 700; color: #fff; margin-bottom: 0.25rem; }
+.journey-badge-org { font-size: 0.8rem; color: rgba(255, 255, 255, 0.45); font-weight: 500; }
+
+/* ─── Timeline ─── */
+.journey-timeline {
+  position: relative; max-width: 720px; margin: 2.5rem auto 0; padding-left: 3.5rem;
+}
+.journey-timeline-line {
+  position: absolute; left: 1.1rem; top: 0; bottom: 0; width: 2px;
+  background: linear-gradient(180deg, #10B981 0%, #38BDF8 50%, #06B6D4 100%); opacity: 0.3;
+}
+.journey-timeline-entry {
+  display: flex; gap: 1.5rem; padding-bottom: 2.5rem; position: relative;
+}
+.journey-timeline-marker {
+  position: absolute; left: -3.5rem;
+  display: flex; flex-direction: column; align-items: center; gap: 0.25rem;
+}
+.journey-timeline-icon {
+  width: 36px; height: 36px; border-radius: 50%;
+  background: rgba(16, 185, 129, 0.15);
+  border: 2px solid rgba(16, 185, 129, 0.4);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1rem; position: relative; z-index: 1;
+}
+.journey-timeline-year {
+  font-size: 0.7rem; font-weight: 700; color: #10B981;
+  font-family: 'JetBrains Mono', monospace;
+}
+.journey-timeline-content {
+  flex: 1; padding: 1.25rem 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px; transition: all 0.3s ease;
+}
+.journey-timeline-content:hover {
+  border-color: rgba(16, 185, 129, 0.2);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+.journey-timeline-title { font-size: 1.1rem; font-weight: 700; color: #fff; margin: 0 0 0.5rem; }
+.journey-timeline-desc { font-size: 0.9rem; line-height: 1.6; color: rgba(255, 255, 255, 0.6); margin: 0 0 0.75rem; }
+.journey-timeline-tags, .journey-project-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.journey-tag {
+  display: inline-block; padding: 0.2rem 0.65rem; border-radius: 999px;
+  font-size: 0.72rem; font-weight: 600;
+  background: rgba(16, 185, 129, 0.1); color: #10B981;
+  border: 1px solid rgba(16, 185, 129, 0.2); letter-spacing: 0.02em;
+}
+.journey-tag--sm { font-size: 0.68rem; padding: 0.15rem 0.5rem; }
+
+/* ─── Projects Grid ─── */
+.journey-projects-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem; margin-top: 2.5rem;
+}
+.journey-project-card {
+  padding: 2rem; border-radius: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transition: all 0.35s ease;
+}
+.journey-project-card:hover {
+  border-color: rgba(56, 189, 248, 0.25);
+  transform: translateY(-3px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
+}
+.journey-project-icon { font-size: 2rem; margin-bottom: 0.75rem; }
+.journey-project-name { font-size: 1.15rem; font-weight: 700; color: #fff; margin: 0 0 0.5rem; }
+.journey-project-desc { font-size: 0.88rem; line-height: 1.6; color: rgba(255, 255, 255, 0.55); margin: 0 0 1rem; }
+
+/* ─── Philosophy Terminal ─── */
+.journey-philosophy { max-width: 600px; margin: 0 auto; }
+.journey-philosophy-terminal {
+  background: rgba(10, 22, 40, 0.95);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  border-radius: 12px; overflow: hidden;
+  box-shadow: 0 0 60px rgba(16, 185, 129, 0.06);
+}
+.journey-philosophy-terminal .terminal__body { padding: 1.25rem 1.5rem 1.5rem; }
+.journey-philosophy-terminal .terminal__prompt { color: rgba(255, 255, 255, 0.35) !important; font-style: italic; }
+
+/* ─── Connect Grid ─── */
+.journey-connect-grid {
+  display: flex; justify-content: center; gap: 1.25rem;
+  flex-wrap: wrap; margin-top: 2rem;
+}
+.journey-connect-card {
+  display: flex; flex-direction: column; align-items: center; gap: 0.5rem;
+  padding: 1.25rem 2rem; border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  text-decoration: none; transition: all 0.3s ease; min-width: 120px;
+}
+.journey-connect-card:hover {
+  border-color: rgba(16, 185, 129, 0.3);
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  text-decoration: none;
+}
+.journey-connect-icon { font-size: 1.75rem; }
+.journey-connect-label { font-size: 0.8rem; font-weight: 600; color: rgba(255, 255, 255, 0.7); }
+.journey-connect-card:hover .journey-connect-label { color: #10B981; }
+.journey-cta-buttons { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+/* ─── Captain Journey Link ─── */
+.captain-journey-link {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  position: absolute; bottom: 0; left: 50%; transform: translateX(-50%);
+  font-size: 0.78rem; font-weight: 600; color: #10B981;
+  text-decoration: none; transition: all 0.25s ease;
+  font-family: 'JetBrains Mono', monospace; white-space: nowrap; z-index: 2;
+}
+.captain-journey-link:hover { color: #38BDF8; text-decoration: none; }
+
+/* ─── Light Mode Journey ─── */
+[data-theme='light'] .journey-hero {
+  background: linear-gradient(160deg, #F0F9FF 0%, #E0F2FE 30%, #F0FDF4 60%, #ECFDF5 100%);
+}
+[data-theme='light'] .journey-hero-title { color: #0F172A; }
+[data-theme='light'] .journey-hero-subtitle { color: #475569; }
+[data-theme='light'] .journey-stats-section {
+  background: linear-gradient(180deg, #F8FAFC 0%, #F0F9FF 100%);
+  border-color: rgba(16, 185, 129, 0.12);
+}
+[data-theme='light'] .journey-stat-card {
+  background: #fff; border-color: rgba(16, 185, 129, 0.15);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+[data-theme='light'] .journey-stat-label { color: #64748B; }
+[data-theme='light'] .journey-section { background: #F8FAFC; }
+[data-theme='light'] .journey-section--badges { background: linear-gradient(180deg, #F0F9FF 0%, #F8FAFC 100%); }
+[data-theme='light'] .journey-section--projects { background: linear-gradient(180deg, #F8FAFC 0%, #F0F9FF 100%); }
+[data-theme='light'] .journey-section--cta { background: linear-gradient(180deg, #F0F9FF 0%, #F8FAFC 100%); }
+[data-theme='light'] .journey-section .section__title { color: #0F172A; }
+[data-theme='light'] .journey-badge-card,
+[data-theme='light'] .journey-timeline-content,
+[data-theme='light'] .journey-project-card {
+  background: #fff; border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+[data-theme='light'] .journey-badge-title,
+[data-theme='light'] .journey-timeline-title,
+[data-theme='light'] .journey-project-name { color: #0F172A; }
+[data-theme='light'] .journey-badge-org { color: #64748B; }
+[data-theme='light'] .journey-timeline-desc,
+[data-theme='light'] .journey-project-desc { color: #64748B; }
+[data-theme='light'] .journey-connect-card {
+  background: #fff; border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+[data-theme='light'] .journey-connect-label { color: #475569; }
+[data-theme='light'] .journey-terminal,
+[data-theme='light'] .journey-philosophy-terminal { background: #1E293B; }
+[data-theme='light'] .journey-matrix-rain { display: none; }
+
+/* ─── Journey Responsive ─── */
+@media (max-width: 996px) {
+  .journey-hero-container { grid-template-columns: 1fr; }
+  .journey-hero-title { font-size: 2.8rem; }
+  .journey-stats-grid { grid-template-columns: repeat(3, 1fr); }
+  .journey-badges-grid { grid-template-columns: repeat(2, 1fr); }
+  .journey-projects-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 600px) {
+  .journey-hero { padding: 3.5rem 0 2.5rem; }
+  .journey-hero-title { font-size: 2.2rem; }
+  .journey-stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .journey-badges-grid { grid-template-columns: 1fr; }
+  .journey-timeline { padding-left: 3rem; }
+  .journey-timeline-marker { left: -3rem; }
+  .journey-terminal { font-size: 0.72rem; }
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -421,6 +421,9 @@ function CaptainSection({ ghStats }: { ghStats: { stars: number; forks: number; 
               className="captain-image"
             />
             <div className="captain-badge-tag">Founder & Captain</div>
+            <Link to="/journey" className="captain-journey-link">
+              ~/my-journey &rarr;
+            </Link>
           </div>
           <div className="captain-text">
             <h2 className="captain-heading">

--- a/website/src/pages/journey.tsx
+++ b/website/src/pages/journey.tsx
@@ -325,29 +325,29 @@ export default function JourneyPage(): React.ReactElement {
               year="2019"
               icon="&#x1F30D;"
               title="Going Global"
-              desc="Crossed 100+ sessions across multiple countries. Recognized as an AWS Community Builder and started mentoring developers worldwide."
-              tags={['AWS Community Builder', 'Mentoring', 'Global']}
+              desc="Crossed 100+ sessions across multiple countries. Started mentoring developers worldwide and evangelizing cloud-native tech on the global stage."
+              tags={['Public Speaking', 'Mentoring', 'Global']}
             />
             <TimelineEntry
               year="2021"
               icon="&#x1F527;"
               title="AWS Community Builder"
-              desc="Recognized as an AWS Community Builder for Cloud Architecture & Containers. Deepened expertise in container orchestration and cloud-native patterns."
+              desc="Recognized as an AWS Community Builder for Containers. Deepened expertise in container orchestration, cloud-native patterns, and ECS/EKS architectures."
               tags={['AWS Community Builder', 'Containers', 'Cloud Architecture']}
             />
             <TimelineEntry
               year="2022"
               icon="&#x1F3DB;"
               title="Building Local Communities"
-              desc="Founded CNCF Gandhinagar, HashiCorp Gandhinagar, and GDG Cloud Gandhinagar chapters — bringing cloud-native communities together on the ground."
-              tags={['CNCF', 'HashiCorp', 'GDG Cloud', 'Gandhinagar']}
+              desc="Started organizing local tech communities — bringing developers together through meetups, workshops, and hackathons to learn and build in the open."
+              tags={['Community', 'Meetups', 'Workshops', 'Hackathons']}
             />
             <TimelineEntry
               year="2023"
               icon="&#x2693;"
-              title="CloudCaptain Sets Sail"
-              desc="Launched CloudCaptain as a free, open-source learning platform for Cloud and DevOps. What started as curated notes grew into a community-driven resource hub."
-              tags={['CloudCaptain', 'Open Source', 'Community']}
+              title="CloudCaptain & Community Chapters"
+              desc="Launched CloudCaptain as a free, open-source learning platform. Founded CNCF Gandhinagar, HashiCorp Gandhinagar, and GDG Cloud Gandhinagar chapters — scaling community impact."
+              tags={['CloudCaptain', 'CNCF', 'HashiCorp', 'GDG Cloud']}
             />
             <TimelineEntry
               year="2024"

--- a/website/src/pages/journey.tsx
+++ b/website/src/pages/journey.tsx
@@ -1,0 +1,454 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+
+/* ─── Scroll Reveal Hook ─── */
+function useScrollReveal() {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) entry.target.classList.add('revealed');
+        });
+      },
+      { threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
+    );
+    const targets = el.querySelectorAll('.reveal');
+    targets.forEach((t) => observer.observe(t));
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+  return ref;
+}
+
+/* ─── Count-up Hook ─── */
+function useCountUp(target: number, suffix = '', duration = 1500) {
+  const [count, setCount] = useState(0);
+  const [started, setStarted] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !started) setStarted(true);
+      },
+      { threshold: 0.5 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [started]);
+
+  useEffect(() => {
+    if (!started) return;
+    const startTime = performance.now();
+    const step = (now: number) => {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setCount(Math.round(eased * target));
+      if (progress < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }, [started, target, duration]);
+
+  return { ref, display: `${count}${suffix}` };
+}
+
+/* ─── Terminal Intro ─── */
+function TerminalIntro() {
+  const lines = [
+    '$ whoami',
+    'mehul-patel :: docker-captain :: gde-cloud :: open-source-advocate',
+    '',
+    '$ cat /etc/journey.conf',
+    'EXPERIENCE="12+ years"',
+    'SESSIONS_DELIVERED="500+"',
+    'COUNTRIES_REACHED="25+"',
+    'DEVELOPERS_IMPACTED="50,000+"',
+    'MENTEES="305+"',
+    'RATING="4.9/5"',
+    '',
+    '$ uname -a',
+    'Linux cloudcaptain 6.1.0-mehul #1 SMP OPEN_SOURCE x86_64 GNU/Linux',
+  ];
+
+  const [visibleLines, setVisibleLines] = useState(0);
+
+  useEffect(() => {
+    if (visibleLines < lines.length) {
+      const delay = lines[visibleLines] === '' ? 100 : lines[visibleLines].startsWith('$') ? 400 : 80;
+      const timer = setTimeout(() => setVisibleLines((v) => v + 1), delay);
+      return () => clearTimeout(timer);
+    }
+  }, [visibleLines]);
+
+  return (
+    <div className="journey-terminal">
+      <div className="terminal__header">
+        <span className="terminal__dot terminal__dot--red" />
+        <span className="terminal__dot terminal__dot--yellow" />
+        <span className="terminal__dot terminal__dot--green" />
+        <span className="terminal__title">mehul@cloudcaptain ~ journey</span>
+      </div>
+      <div className="terminal__body">
+        {lines.slice(0, visibleLines).map((line, i) => {
+          if (line === '') return <div key={i} className="terminal__spacer" />;
+          if (line.startsWith('$')) {
+            return (
+              <div key={i} className="terminal__line">
+                <span className="terminal__prompt">$ </span>
+                <span className="terminal__cmd">{line.slice(2)}</span>
+              </div>
+            );
+          }
+          if (line.includes('=')) {
+            const [key, val] = line.split('=');
+            return (
+              <div key={i} className="terminal__line terminal__config-line">
+                <span className="terminal__config-key">{key}</span>
+                <span className="terminal__config-eq">=</span>
+                <span className="terminal__config-val">{val}</span>
+              </div>
+            );
+          }
+          return (
+            <div key={i} className="terminal__output">
+              <span>{line}</span>
+            </div>
+          );
+        })}
+        {visibleLines < lines.length && (
+          <div className="terminal__line">
+            <span className="terminal__cursor">|</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Stat Card ─── */
+function JourneyStat({ number, suffix, label, icon }: { number: number; suffix: string; label: string; icon: string }) {
+  const { ref, display } = useCountUp(number, suffix);
+  return (
+    <div ref={ref} className="journey-stat-card">
+      <div className="journey-stat-icon">{icon}</div>
+      <div className="journey-stat-number">{display}</div>
+      <div className="journey-stat-label">{label}</div>
+    </div>
+  );
+}
+
+/* ─── Timeline Entry ─── */
+function TimelineEntry({
+  year,
+  title,
+  desc,
+  icon,
+  tags,
+}: {
+  year: string;
+  title: string;
+  desc: string;
+  icon: string;
+  tags?: string[];
+}) {
+  return (
+    <div className="journey-timeline-entry reveal">
+      <div className="journey-timeline-marker">
+        <div className="journey-timeline-icon">{icon}</div>
+        <div className="journey-timeline-year">{year}</div>
+      </div>
+      <div className="journey-timeline-content">
+        <h3 className="journey-timeline-title">{title}</h3>
+        <p className="journey-timeline-desc">{desc}</p>
+        {tags && (
+          <div className="journey-timeline-tags">
+            {tags.map((tag) => (
+              <span key={tag} className="journey-tag">{tag}</span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Badge Card ─── */
+function BadgeCard({ title, org, icon, color }: { title: string; org: string; icon: string; color: string }) {
+  return (
+    <div className="journey-badge-card reveal" style={{ '--badge-accent': color } as React.CSSProperties}>
+      <div className="journey-badge-icon">{icon}</div>
+      <div className="journey-badge-title">{title}</div>
+      <div className="journey-badge-org">{org}</div>
+    </div>
+  );
+}
+
+/* ─── Open Source Project Card ─── */
+function ProjectCard({ name, desc, icon, tags }: { name: string; desc: string; icon: string; tags: string[] }) {
+  return (
+    <div className="journey-project-card reveal">
+      <div className="journey-project-icon">{icon}</div>
+      <h3 className="journey-project-name">{name}</h3>
+      <p className="journey-project-desc">{desc}</p>
+      <div className="journey-project-tags">
+        {tags.map((t) => (
+          <span key={t} className="journey-tag journey-tag--sm">{t}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Main Page ─── */
+export default function JourneyPage(): React.ReactElement {
+  const heroRef = useScrollReveal();
+  const statsRef = useScrollReveal();
+  const timelineRef = useScrollReveal();
+  const badgesRef = useScrollReveal();
+  const projectsRef = useScrollReveal();
+  const ctaRef = useScrollReveal();
+
+  return (
+    <Layout
+      title="The Captain's Journey"
+      description="Follow Mehul Patel's 12+ year journey through DevOps, Cloud, and Open Source — from community builder to Docker Captain and Google Developer Expert.">
+
+      {/* ═══ HERO ═══ */}
+      <div className="journey-hero" ref={heroRef}>
+        <div className="journey-hero-bg" aria-hidden="true">
+          <div className="journey-matrix-rain" />
+        </div>
+        <div className="container journey-hero-container">
+          <div className="journey-hero-left reveal">
+            <div className="journey-hero-badge">
+              <span className="journey-penguin">&#x1F427;</span> Open Source Journey
+            </div>
+            <h1 className="journey-hero-title">
+              <span className="journey-prompt">~/</span>The Captain's
+              <br />
+              <span className="journey-hero-accent">Journey</span>
+            </h1>
+            <p className="journey-hero-subtitle">
+              12+ years navigating the open-source seas. From writing my first
+              <code> bash</code> script to becoming a Docker Captain, Google Developer
+              Expert, and mentoring 50,000+ developers across 25+ countries.
+            </p>
+            <div className="journey-hero-cta">
+              <a className="btn-primary" href="https://nomadicmehul.dev/" target="_blank" rel="noopener noreferrer">
+                Full Profile
+              </a>
+              <Link className="btn-secondary" to="/">
+                Back to CloudCaptain
+              </Link>
+            </div>
+          </div>
+          <div className="journey-hero-right reveal">
+            <TerminalIntro />
+          </div>
+        </div>
+      </div>
+
+      {/* ═══ STATS ═══ */}
+      <div className="journey-stats-section" ref={statsRef}>
+        <div className="container">
+          <div className="journey-stats-grid reveal">
+            <JourneyStat number={12} suffix="+" label="Years Experience" icon="&#x1F4BB;" />
+            <JourneyStat number={500} suffix="+" label="Sessions Delivered" icon="&#x1F399;" />
+            <JourneyStat number={25} suffix="+" label="Countries" icon="&#x1F30D;" />
+            <JourneyStat number={50} suffix="K+" label="Developers Reached" icon="&#x1F465;" />
+            <JourneyStat number={305} suffix="+" label="Mentees" icon="&#x1F393;" />
+            <JourneyStat number={49} suffix="/5" label="Avg. Rating" icon="&#x2B50;" />
+          </div>
+        </div>
+      </div>
+
+      {/* ═══ CERTIFICATIONS & RECOGNITIONS ═══ */}
+      <div className="journey-section journey-section--badges" ref={badgesRef}>
+        <div className="container">
+          <h2 className="section__title reveal">
+            <span className="journey-prompt">$ </span>Recognitions & Titles
+          </h2>
+          <p className="section__subtitle reveal">
+            Earned through years of community leadership and open-source contributions.
+          </p>
+          <div className="journey-badges-grid">
+            <BadgeCard title="Docker Captain" org="Docker Inc." icon="&#x1F433;" color="#2496ED" />
+            <BadgeCard title="Google Developer Expert" org="Google Cloud Platform" icon="&#x2601;" color="#4285F4" />
+            <BadgeCard title="AWS Community Builder" org="Amazon Web Services" icon="&#x1F527;" color="#FF9900" />
+            <BadgeCard title="Auth0 Ambassador" org="Auth0 by Okta" icon="&#x1F510;" color="#EB5424" />
+            <BadgeCard title="Mozilla Reps Council" org="Mozilla Foundation" icon="&#x1F525;" color="#FF7139" />
+            <BadgeCard title="Open Source Advocate" org="OSW & OSCF Founder" icon="&#x1F427;" color="#10B981" />
+          </div>
+        </div>
+      </div>
+
+      {/* ═══ TIMELINE ═══ */}
+      <div className="journey-section journey-section--timeline" ref={timelineRef}>
+        <div className="container">
+          <h2 className="section__title reveal">
+            <span className="journey-prompt">$ </span>git log --oneline
+          </h2>
+          <p className="section__subtitle reveal">
+            Key commits in the journey from engineer to community captain.
+          </p>
+          <div className="journey-timeline">
+            <div className="journey-timeline-line" aria-hidden="true" />
+            <TimelineEntry
+              year="2012"
+              icon="&#x1F4BB;"
+              title="The First Commit"
+              desc="Started my tech career with a passion for Linux and automation. Wrote my first shell scripts and fell in love with the terminal."
+              tags={['Linux', 'Bash', 'Automation']}
+            />
+            <TimelineEntry
+              year="2015"
+              icon="&#x2601;"
+              title="Entered the Cloud"
+              desc="Dove deep into AWS and cloud-native architecture. Started evangelizing DevOps practices and containerization within my team."
+              tags={['AWS', 'DevOps', 'Docker']}
+            />
+            <TimelineEntry
+              year="2017"
+              icon="&#x1F399;"
+              title="Speaking & Community Building"
+              desc="Delivered my first public talks. Founded local tech meetups and began organizing community events around cloud and DevOps."
+              tags={['Public Speaking', 'Meetups', 'GDG']}
+            />
+            <TimelineEntry
+              year="2019"
+              icon="&#x1F30D;"
+              title="Going Global"
+              desc="Crossed 100+ sessions across multiple countries. Recognized as an AWS Community Builder and started mentoring developers worldwide."
+              tags={['AWS Community Builder', 'Mentoring', 'Global']}
+            />
+            <TimelineEntry
+              year="2021"
+              icon="&#x1F527;"
+              title="AWS Community Builder"
+              desc="Recognized as an AWS Community Builder for Cloud Architecture & Containers. Deepened expertise in container orchestration and cloud-native patterns."
+              tags={['AWS Community Builder', 'Containers', 'Cloud Architecture']}
+            />
+            <TimelineEntry
+              year="2022"
+              icon="&#x1F3DB;"
+              title="Building Local Communities"
+              desc="Founded CNCF Gandhinagar, HashiCorp Gandhinagar, and GDG Cloud Gandhinagar chapters — bringing cloud-native communities together on the ground."
+              tags={['CNCF', 'HashiCorp', 'GDG Cloud', 'Gandhinagar']}
+            />
+            <TimelineEntry
+              year="2023"
+              icon="&#x2693;"
+              title="CloudCaptain Sets Sail"
+              desc="Launched CloudCaptain as a free, open-source learning platform for Cloud and DevOps. What started as curated notes grew into a community-driven resource hub."
+              tags={['CloudCaptain', 'Open Source', 'Community']}
+            />
+            <TimelineEntry
+              year="2024"
+              icon="&#x1F433;"
+              title="Docker Captain"
+              desc="Appointed as an official Docker Captain — recognized for deep container expertise, community leadership, and evangelizing Docker across 25+ countries."
+              tags={['Docker Captain', 'Containers', 'Community Leader']}
+            />
+            <TimelineEntry
+              year="2025"
+              icon="&#x1F30D;"
+              title="Germany, GDE & Grafana"
+              desc="Moved to Germany and became a Google Developer Expert for Cloud. Took on the role of Grafana and Friends Berlin organizer — bridging observability and community."
+              tags={['GDE', 'Google Cloud', 'Grafana', 'Berlin']}
+            />
+            <TimelineEntry
+              year="2026"
+              icon="&#x1F916;"
+              title="Shipping AI-Native Infrastructure"
+              desc="Now building at the frontier where AI meets DevOps — crafting intelligent automation, MCP-powered cloud ops, and Docker Sandboxes that let AI agents ship code safely."
+              tags={['AI Agents', 'MCP', 'Claude', 'Docker Sandboxes']}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* ═══ OPEN SOURCE PROJECTS ═══ */}
+      <div className="journey-section journey-section--projects" ref={projectsRef}>
+        <div className="container">
+          <h2 className="section__title reveal">
+            <span className="journey-prompt">$ </span>ls ~/open-source/
+          </h2>
+          <p className="section__subtitle reveal">
+            Some of the open-source projects I've built for the community.
+          </p>
+          <div className="journey-projects-grid">
+            <ProjectCard
+              name="CloudCaptain"
+              desc="Free, open-source learning platform for Cloud, DevOps, AI & Operations with curated paths and hands-on exercises."
+              icon="&#x2693;"
+              tags={['Docusaurus', 'TypeScript', 'DevOps', 'Community']}
+            />
+            <ProjectCard
+              name="Dispatch"
+              desc="AI-powered CLI that uses Claude to automatically resolve GitHub issues with intelligent code analysis."
+              icon="&#x1F916;"
+              tags={['AI', 'Claude', 'GitHub', 'Python']}
+            />
+            <ProjectCard
+              name="Azure MCP Server"
+              desc="Model Context Protocol implementation for Azure services, enabling AI agents to interact with cloud resources."
+              icon="&#x2601;"
+              tags={['Azure', 'MCP', 'TypeScript', 'AI']}
+            />
+            <ProjectCard
+              name="Hello GenAI"
+              desc="Educational collection of generative AI applications to help developers get started with AI technologies."
+              icon="&#x1F9E0;"
+              tags={['GenAI', 'Education', 'Python', 'LLMs']}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* ═══ CONNECT ═══ */}
+      <div className="journey-section journey-section--cta" ref={ctaRef}>
+        <div className="container" style={{ textAlign: 'center' }}>
+          <h2 className="section__title reveal">
+            <span className="journey-prompt">$ </span>Let's Connect
+          </h2>
+          <p className="section__subtitle reveal">
+            Whether you want to collaborate on open source, invite me to speak, or just say hello.
+          </p>
+          <div className="journey-connect-grid reveal">
+            <a href="https://github.com/nomadicmehul" target="_blank" rel="noopener noreferrer" className="journey-connect-card">
+              <span className="journey-connect-icon">&#x1F4BB;</span>
+              <span className="journey-connect-label">GitHub</span>
+            </a>
+            <a href="https://twitter.com/nomadicmehul" target="_blank" rel="noopener noreferrer" className="journey-connect-card">
+              <span className="journey-connect-icon">&#x1F426;</span>
+              <span className="journey-connect-label">Twitter</span>
+            </a>
+            <a href="https://nomadicmehul.dev/" target="_blank" rel="noopener noreferrer" className="journey-connect-card">
+              <span className="journey-connect-icon">&#x1F310;</span>
+              <span className="journey-connect-label">Website</span>
+            </a>
+            <a href="https://buymeacoffee.com/nomadicmehul" target="_blank" rel="noopener noreferrer" className="journey-connect-card">
+              <span className="journey-connect-icon">&#x2615;</span>
+              <span className="journey-connect-label">Buy Me a Coffee</span>
+            </a>
+          </div>
+          <div className="journey-cta-buttons reveal" style={{ marginTop: '2rem' }}>
+            <Link className="btn-primary" to="/career-paths">
+              Explore Career Paths
+            </Link>
+            <Link className="btn-secondary" to="/docs/learning-paths/devops">
+              Start Learning DevOps
+            </Link>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- New **Captain's Journey** page (`/journey`) with a Linux & open-source inspired design
- Hero section with terminal UI showing system config, stats bar with count-up animations, badge cards, timeline, featured projects, open-source philosophy section, and CTA
- Scroll-reveal animations throughout the page
- Navbar and footer links added for Captain's Journey
- `~/my-journey →` link added under founder photo on homepage
- Minor fix to captain badge positioning on homepage

## Files changed
- `website/src/pages/journey.tsx` — New page (454 lines)
- `website/src/css/custom.css` — Journey page styles + badge fix
- `website/docusaurus.config.ts` — Navbar & footer link
- `website/src/pages/index.tsx` — Journey link on founder section

## Test plan
- [x] Verify `/journey` page loads and all sections render
- [x] Check scroll-reveal and count-up animations work
- [x] Confirm navbar and footer links navigate correctly
- [x] Test responsive layout on mobile/tablet
- [x] Verify `npm run build` passes