### PR TITLE
Add: Google SRE Book complete chapter guide to SRE learning path

### DIFF
--- a/website/docs/learning-paths/sre.md
+++ b/website/docs/learning-paths/sre.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
 title: "SRE Learning Path"
-description: "Site Reliability Engineering roadmap"
+description: "Site Reliability Engineering roadmap with Google SRE Book chapter guide"
 ---
 
 # SRE Learning Path
@@ -38,23 +38,94 @@ Build and operate reliable, scalable, and efficient systems.
 - Disaster recovery and DR drills
 - Change management
 
-## Essential Reading
+---
 
-| Book | Author |
-|:-----|:-------|
-| Site Reliability Engineering | Google |
-| The Site Reliability Workbook | Google |
-| Implementing Service Level Objectives | Alex Hidalgo |
-| Observability Engineering | Charity Majors et al. |
+## Google SRE Book — Free Chapter Guide
+
+The **Site Reliability Engineering** book by Google is available for free online. Below is the complete table of contents with direct links to every chapter.
+
+> All chapters link to [sre.google/sre-book](https://sre.google/sre-book/table-of-contents/) — read the full book for free.
+
+### Part I — Introduction
+
+| Ch | Title | Key Topics |
+|:---|:------|:-----------|
+| 1 | [Introduction](https://sre.google/sre-book/introduction/) | What SRE is, how Google does it, tenets of SRE |
+| 2 | [The Production Environment at Google](https://sre.google/sre-book/production-environment/) | Hardware, software infrastructure, networking, Borg |
+
+### Part II — Principles
+
+| Ch | Title | Key Topics |
+|:---|:------|:-----------|
+| 3 | [Embracing Risk](https://sre.google/sre-book/embracing-risk/) | Risk tolerance, error budgets, balancing reliability vs. velocity |
+| 4 | [Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) | SLIs, SLOs, SLAs, choosing targets, control loops |
+| 5 | [Eliminating Toil](https://sre.google/sre-book/eliminating-toil/) | Defining toil, measuring toil, automation strategies |
+| 6 | [Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) | Symptoms vs. causes, black-box/white-box monitoring, alerting |
+| 7 | [The Evolution of Automation at Google](https://sre.google/sre-book/automation-at-google/) | Automation hierarchy, platform-based automation |
+| 8 | [Release Engineering](https://sre.google/sre-book/release-engineering/) | Build/release pipeline, hermetic builds, release philosophy |
+| 9 | [Simplicity](https://sre.google/sre-book/simplicity/) | Boring is good, minimal APIs, modularity, release simplicity |
+
+### Part III — Practices
+
+| Ch | Title | Key Topics |
+|:---|:------|:-----------|
+| 10 | [Practical Alerting](https://sre.google/sre-book/practical-alerting/) | Borgmon, time-series monitoring, alerting rules, dashboards |
+| 11 | [Being On-Call](https://sre.google/sre-book/being-on-call/) | On-call balance, compensation, operational load, feeling safe |
+| 12 | [Effective Troubleshooting](https://sre.google/sre-book/effective-troubleshooting/) | Problem reports, triage, examine, diagnose, test/treat |
+| 13 | [Emergency Response](https://sre.google/sre-book/emergency-response/) | Real-world emergencies, learning from incidents, drills |
+| 14 | [Managing Incidents](https://sre.google/sre-book/managing-incidents/) | Incident command, roles, communication, declared incidents |
+| 15 | [Postmortem Culture: Learning from Failure](https://sre.google/sre-book/postmortem-culture/) | Blameless postmortems, collaboration, continuous improvement |
+| 16 | [Tracking Outages](https://sre.google/sre-book/tracking-outages/) | Escalator, Outalator, aggregation, tagging, reporting |
+| 17 | [Testing for Reliability](https://sre.google/sre-book/testing-reliability/) | Unit/integration/system testing, production tests, canary |
+| 18 | [Software Engineering in SRE](https://sre.google/sre-book/software-engineering-in-sre/) | SRE as software engineers, Auxon case study |
+| 19 | [Load Balancing at the Frontend](https://sre.google/sre-book/load-balancing-frontend/) | DNS load balancing, virtual IPs, anycast |
+| 20 | [Load Balancing in the Datacenter](https://sre.google/sre-book/load-balancing-datacenter/) | Subset selection, backend health, weighted round robin |
+| 21 | [Handling Overload](https://sre.google/sre-book/handling-overload/) | Client-side throttling, criticality, graceful degradation |
+| 22 | [Addressing Cascading Failures](https://sre.google/sre-book/addressing-cascading-failures/) | Causes, prevention, mitigation, resource exhaustion |
+| 23 | [Managing Critical State](https://sre.google/sre-book/managing-critical-state/) | Distributed consensus, Paxos, Raft, leader election |
+| 24 | [Distributed Periodic Scheduling](https://sre.google/sre-book/distributed-periodic-scheduling/) | Cron at scale, idempotency, large-scale scheduling |
+| 25 | [Data Processing Pipelines](https://sre.google/sre-book/data-processing-pipelines/) | Pipeline design patterns, Workflow, periodic pipelines |
+| 26 | [Data Integrity](https://sre.google/sre-book/data-integrity/) | Backups, recovery, replication, ACID, soft deletes |
+| 27 | [Reliable Product Launches at Scale](https://sre.google/sre-book/reliable-product-launches/) | Launch coordination, checklists, progressive rollouts |
+
+### Part IV — Management
+
+| Ch | Title | Key Topics |
+|:---|:------|:-----------|
+| 28 | [Accelerating SREs to On-Call](https://sre.google/sre-book/accelerating-sre-on-call/) | Training, reverse engineering, shadowing, onboarding |
+| 29 | [Dealing with Interrupts](https://sre.google/sre-book/dealing-with-interrupts/) | Interrupt management, flow state, operational vs. project work |
+| 30 | [Embedding an SRE to Recover from Operational Overload](https://sre.google/sre-book/operational-overload/) | Team health, SRE embedding, operational recovery |
+| 31 | [Communication and Collaboration in SRE](https://sre.google/sre-book/communication-and-collaboration/) | Production meetings, collaboration models, knowledge sharing |
+| 32 | [The Evolving SRE Engagement Model](https://sre.google/sre-book/evolving-sre-engagement-model/) | PRR model, early engagement, frameworks, SRE teams |
+
+### Part V — Conclusions
+
+| Ch | Title | Key Topics |
+|:---|:------|:-----------|
+| 33 | [Lessons Learned from Other Industries](https://sre.google/sre-book/lessons-learned/) | Aviation, healthcare, nuclear — parallels to SRE |
+| 34 | [Conclusion](https://sre.google/sre-book/conclusion/) | SRE future, key takeaways |
+
+### Appendices
+
+| ID | Title | Description |
+|:---|:------|:-----------|
+| A | [Availability Table](https://sre.google/sre-book/availability-table/) | Nines of availability with downtime calculations |
+| B | [Best Practices for Production Services](https://sre.google/sre-book/service-best-practices/) | Collected best practices checklist |
+| C | [Example Incident State Document](https://sre.google/sre-book/incident-document/) | Template for tracking incidents |
+| D | [Example Postmortem](https://sre.google/sre-book/example-postmortem/) | Full postmortem example from Shakespeare service |
+| E | [Launch Coordination Checklist](https://sre.google/sre-book/launch-checklist/) | Pre-launch and launch-day checklist |
+| F | [Example Production Meeting Minutes](https://sre.google/sre-book/production-meeting/) | How Google runs production review meetings |
+
+---
 
 ## Recommended Reading
 
 | Book | Author |
 |:-----|:-------|
-| Site Reliability Engineering | Google (Betsy Beyer et al.) |
-| The Site Reliability Workbook | Google (Betsy Beyer et al.) |
-| Building Secure and Reliable Systems | Google (Heather Adkins et al.) |
-| Training Site Reliability Engineers | Google |
+| [Site Reliability Engineering](https://sre.google/sre-book/table-of-contents/) | Google (Betsy Beyer et al.) — Free online |
+| [The Site Reliability Workbook](https://sre.google/workbook/table-of-contents/) | Google (Betsy Beyer et al.) — Free online |
+| [Building Secure and Reliable Systems](https://sre.google/books/building-secure-reliable-systems/) | Google (Heather Adkins et al.) — Free online |
 | Implementing Service Level Objectives | Alex Hidalgo |
+| Observability Engineering | Charity Majors et al. |
 
-All SRE content from these books has been integrated into the [SRE Practices](/docs/learning-paths/sre-practices) guide above.
+All SRE content from these books has been integrated into the [SRE Practices](/docs/learning-paths/sre-practices) guide.

--- a/website/docs/tools/observability/index.md
+++ b/website/docs/tools/observability/index.md
@@ -1,15 +1,53 @@
 ---
 title: "Observability & SRE"
-description: "Monitoring and observability"
+description: "Monitoring, observability, and SRE practices for reliable systems"
 ---
 
 # Observability & SRE
 
 Prometheus, Grafana, and SRE practices for reliable systems.
 
-## Resources
+## Core Concepts
 
-Check back soon for curated resources, or [contribute](https://github.com/nomadicmehul/CloudCaptain) to add content!
+| Concept | Description |
+|:--------|:-----------|
+| **Monitoring** | Collecting, processing, and aggregating metrics to understand system health |
+| **Observability** | Ability to understand internal state from external outputs (metrics, logs, traces) |
+| **Alerting** | Notifying humans when systems need attention |
+| **SLOs/SLIs** | Measuring and targeting reliability with Service Level Objectives and Indicators |
+| **Incident Management** | Detecting, responding to, and learning from outages |
+
+## Key Tools
+
+| Tool | Purpose | Link |
+|:-----|:--------|:-----|
+| Prometheus | Metrics collection and alerting | [prometheus.io](https://prometheus.io/) |
+| Grafana | Dashboards and visualization | [grafana.com](https://grafana.com/) |
+| Alertmanager | Alert routing, grouping, and silencing | [prometheus.io/docs/alerting](https://prometheus.io/docs/alerting/latest/alertmanager/) |
+| Jaeger | Distributed tracing | [jaegertracing.io](https://www.jaegertracing.io/) |
+| OpenTelemetry | Unified observability framework | [opentelemetry.io](https://opentelemetry.io/) |
+| PagerDuty | Incident response and on-call | [pagerduty.com](https://www.pagerduty.com/) |
+
+## Google SRE Book — Observability Chapters
+
+These chapters from the free [Google SRE Book](https://sre.google/sre-book/table-of-contents/) are directly relevant to observability and monitoring:
+
+| Ch | Title | Why It Matters |
+|:---|:------|:---------------|
+| 4 | [Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) | Foundation for what to monitor and alert on |
+| 6 | [Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) | Core monitoring philosophy and approach |
+| 10 | [Practical Alerting](https://sre.google/sre-book/practical-alerting/) | How to build effective alerting systems |
+| 12 | [Effective Troubleshooting](https://sre.google/sre-book/effective-troubleshooting/) | Using observability data to diagnose issues |
+| 15 | [Postmortem Culture](https://sre.google/sre-book/postmortem-culture/) | Learning from failures to improve monitoring |
+| 16 | [Tracking Outages](https://sre.google/sre-book/tracking-outages/) | Aggregating and analyzing incident data |
+| 17 | [Testing for Reliability](https://sre.google/sre-book/testing-reliability/) | Validating monitoring and alerting in production |
+
+> See the full [SRE Learning Path](/docs/learning-paths/sre) for all 34 chapters.
+
+## Further Reading
+
+- [SRE Learning Path](/docs/learning-paths/sre) — Complete roadmap with all Google SRE Book chapters
+- [SRE Practices Guide](/docs/learning-paths/sre-practices) — Deep dive into SLOs, incident management, postmortems
 
 ## Contributing
 


### PR DESCRIPTION
- Add all 34 chapters + 6 appendices from Google SRE Book with direct links
- Organize by book parts (Introduction, Principles, Practices, Management, Conclusions)
- Include key topics summary for each chapter
- Consolidate duplicate reading lists into single Recommended Reading section
- Enhance observability/index.md with core concepts, key tools table, and curated SRE book chapters relevant to monitoring and observability