### PR TITLE
Add: sitemap, RSS, issue/PR templates, SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: 🐛 Bug Report
+description: Report a broken link, rendering issue, or incorrect information on cloudcaptain.io
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below so we can reproduce and fix it quickly.
+
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL
+      description: Which page has the issue?
+      placeholder: https://cloudcaptain.io/docs/tools/docker/
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What went wrong?
+      description: A clear, concise description of the bug.
+      placeholder: Tell us what you saw vs. what you expected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: false
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      options:
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (optional)
+      description: Drag-and-drop images here.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Ask a Question / Discussion
+    url: https://github.com/nomadicmehul/CloudCaptain/discussions
+    about: For general questions, ideas, or learning-path discussions, use GitHub Discussions.
+  - name: ☕ Support the Project
+    url: https://buymeacoffee.com/nomadicmehul
+    about: Love CloudCaptain? Consider buying the captain a coffee.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: ✨ Feature Request
+description: Suggest a new feature, UX improvement, or capability for the site.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the pain point or gap.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and discussions.
+          required: true

--- a/.github/ISSUE_TEMPLATE/new_resource.yml
+++ b/.github/ISSUE_TEMPLATE/new_resource.yml
@@ -1,0 +1,52 @@
+name: 📚 New Resource / Tool Request
+description: Suggest a new tool, learning resource, cheatsheet, or career path to add.
+title: "[Resource]: "
+labels: ["content", "enhancement"]
+body:
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Learning Path
+        - Tool (Docker, K8s, Terraform, etc.)
+        - Cloud Provider (AWS, Azure, GCP)
+        - Interview Prep
+        - Cheatsheet
+        - Career Path
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Resource / Tool Name
+      placeholder: e.g., Pulumi, KubeVirt, OpenTofu
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Why should we add this?
+      description: A short pitch — who benefits, why it matters for Cloud/DevOps/AI-Ops learners.
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Key links
+      description: Official docs, good tutorials, GitHub repo, etc.
+      placeholder: |
+        - Official docs: https://...
+        - Quickstart: https://...
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Want to contribute it yourself?
+      options:
+        - label: I'd like to submit a PR for this.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+Thanks for contributing to CloudCaptain! ⚓
+Please fill out the sections below. Delete anything that doesn't apply.
+-->
+
+## What does this PR do?
+
+<!-- One-line summary of the change. -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature / enhancement
+- [ ] 📚 Content (new tool, cheatsheet, learning path, cloud provider)
+- [ ] 🎨 Style / UI
+- [ ] 🧹 Refactor / cleanup
+- [ ] 📝 Documentation
+- [ ] 🔧 Build / CI / config
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Screenshots (for UI changes)
+
+<!-- Drag-and-drop before/after images here. -->
+
+## Checklist
+
+- [ ] I ran `npm run build` in `website/` and it succeeded
+- [ ] Links in new content resolve and are not broken
+- [ ] Markdown front matter has `title`, `description`, and (if applicable) `sidebar_position`
+- [ ] No `Co-Authored-By` lines in commit messages (per project policy)
+- [ ] Commit messages use imperative mood (`Add: ...`, `Update: ...`, `Fix: ...`)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
         working-directory: ./website
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for showLastUpdateTime in docs
 
       - uses: actions/setup-node@v4
         with:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+CloudCaptain is a continuously-deployed static site. The only "supported version" is the content currently live at [cloudcaptain.io](https://cloudcaptain.io), which is built from the `main` branch.
+
+## Reporting a Vulnerability
+
+If you believe you've found a security issue, **please do not open a public GitHub issue**. Instead:
+
+1. Email the maintainer privately at **security@cloudcaptain.io** (or via the contact form at [nomadicmehul.dev](https://nomadicmehul.dev/)).
+2. Alternatively, use GitHub's [private vulnerability reporting](https://github.com/nomadicmehul/CloudCaptain/security/advisories/new) feature.
+
+Please include:
+
+- A clear description of the issue
+- Steps to reproduce
+- Affected URL(s) or files
+- Any proof-of-concept payloads (if applicable)
+
+We'll acknowledge your report within **72 hours** and aim to publish a fix or mitigation within **7 days** for verified issues.
+
+## Scope
+
+In-scope:
+
+- The `cloudcaptain.io` website and its source in this repository
+- GitHub Actions workflows in `.github/workflows/`
+- Any first-party scripts or components under `website/src/`
+
+Out-of-scope:
+
+- Third-party sites linked from CloudCaptain content
+- Social engineering of maintainers
+- Denial-of-service against GitHub Pages infrastructure
+- Automated vulnerability scanner output without a working proof-of-concept
+
+## Thanks
+
+Responsible disclosure keeps the community safe. Contributors who report valid issues will be credited (with permission) in release notes.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -93,7 +93,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/nomadicmehul/CloudCaptain/tree/main/website/',
-          showLastUpdateTime: false,
+          showLastUpdateTime: true,
           showLastUpdateAuthor: false,
           breadcrumbs: true,
         },
@@ -103,7 +103,22 @@ const config: Config = {
           blogTitle: 'CloudCaptain Blog',
           blogDescription: 'Latest insights on Cloud, DevOps, AI, and Operations',
           postsPerPage: 10,
+          feedOptions: {
+            type: 'all',
+            title: 'CloudCaptain Blog',
+            description: 'Latest insights on Cloud, DevOps, AI, and Operations',
+            copyright: `Copyright © ${new Date().getFullYear()} CloudCaptain Community`,
+            language: 'en',
+          },
         },
+        sitemap: {
+          changefreq: 'weekly',
+          priority: 0.7,
+          ignorePatterns: ['/tags/**'],
+          filename: 'sitemap.xml',
+        },
+        // Google Analytics — add your Measurement ID to enable
+        // gtag: { trackingID: 'G-XXXXXXXXXX', anonymizeIP: true },
         theme: {
           customCss: './src/css/custom.css',
         },
@@ -236,6 +251,21 @@ const config: Config = {
       maxHeadingLevel: 4,
     },
   } satisfies Preset.ThemeConfig,
+
+  plugins: [
+    // Zoom on images in docs/blog for cheatsheets and diagrams
+    [
+      'plugin-image-zoom',
+      {
+        selector: '.markdown img',
+        options: {
+          margin: 24,
+          background: 'rgba(10, 22, 40, 0.9)',
+          scrollOffset: 0,
+        },
+      },
+    ],
+  ],
 
   themes: [
     '@docusaurus/theme-mermaid',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,6 +14,7 @@
         "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "plugin-image-zoom": "^1.2.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -12548,6 +12549,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/medium-zoom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.1.0.tgz",
+      "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==",
+      "license": "MIT"
+    },
     "node_modules/memfs": {
       "version": "4.56.11",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.11.tgz",
@@ -15282,6 +15289,15 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/plugin-image-zoom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/plugin-image-zoom/-/plugin-image-zoom-1.2.0.tgz",
+      "integrity": "sha512-uVCjp4bXuli39gmBs+JQvXMtpfLL+5yWfRIKZyM41d3D9oxGBEHmRzDu9EgusIwmBrKJvF9QuOZENw/9s6G+Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "medium-zoom": "^1.0.4"
       }
     },
     "node_modules/points-on-curve": {

--- a/website/package.json
+++ b/website/package.json
@@ -21,6 +21,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "plugin-image-zoom": "^1.2.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/website/src/pages/404.tsx
+++ b/website/src/pages/404.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+
+const popularDestinations = [
+  { label: '🐧 Linux Master Path', to: '/docs/learning-paths/linux-master' },
+  { label: '🚀 DevOps Path', to: '/docs/learning-paths/devops' },
+  { label: '🤖 AI / ML Ops Path', to: '/docs/learning-paths/ai-ml' },
+  { label: '🐳 Docker', to: '/docs/tools/docker/' },
+  { label: '☸️  Kubernetes', to: '/docs/tools/kubernetes/' },
+  { label: '🏗️  Terraform', to: '/docs/tools/terraform/' },
+  { label: '☁️  AWS', to: '/docs/cloud/aws/' },
+  { label: '🎯 Career Paths', to: '/career-paths' },
+];
+
+export default function NotFound(): JSX.Element {
+  return (
+    <Layout
+      title="404 — Lost at Sea"
+      description="Page not found. Chart a new course with CloudCaptain.">
+      <main
+        style={{
+          minHeight: '70vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '4rem 1.5rem',
+        }}>
+        <div style={{maxWidth: 720, width: '100%', textAlign: 'center'}}>
+          <div
+            style={{
+              fontFamily: 'var(--ifm-font-family-monospace, JetBrains Mono, monospace)',
+              fontSize: '0.9rem',
+              color: 'var(--ifm-color-emphasis-600)',
+              marginBottom: '1rem',
+              textAlign: 'left',
+              background: 'var(--ifm-color-emphasis-100)',
+              borderRadius: 8,
+              padding: '1rem 1.25rem',
+              border: '1px solid var(--ifm-color-emphasis-300)',
+            }}>
+            <span style={{color: '#10B981'}}>$</span> cd /requested/page
+            <br />
+            <span style={{color: '#EF4444'}}>bash: cd: /requested/page: No such file or directory</span>
+            <br />
+            <span style={{color: '#10B981'}}>$</span> exit 404
+          </div>
+
+          <h1 style={{fontSize: '3rem', marginBottom: '0.5rem'}}>🧭 Lost at Sea</h1>
+          <p style={{fontSize: '1.15rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '2rem'}}>
+            The page you're looking for drifted off the map. Let's get you back on course.
+          </p>
+
+          <div
+            style={{
+              display: 'flex',
+              gap: '0.75rem',
+              justifyContent: 'center',
+              flexWrap: 'wrap',
+              marginBottom: '2.5rem',
+            }}>
+            <Link className="button button--primary button--lg" to="/">
+              🏠 Back to Home
+            </Link>
+            <Link className="button button--secondary button--lg" to="/docs/learning-paths/welcome">
+              📚 Browse Learning Paths
+            </Link>
+          </div>
+
+          <h2 style={{fontSize: '1.25rem', marginBottom: '1rem'}}>Popular Destinations</h2>
+          <ul
+            style={{
+              listStyle: 'none',
+              padding: 0,
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+              gap: '0.5rem',
+            }}>
+            {popularDestinations.map((d) => (
+              <li key={d.to}>
+                <Link
+                  to={d.to}
+                  style={{
+                    display: 'block',
+                    padding: '0.75rem 1rem',
+                    border: '1px solid var(--ifm-color-emphasis-300)',
+                    borderRadius: 8,
+                    textDecoration: 'none',
+                    transition: 'all 0.15s ease',
+                  }}>
+                  {d.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          <p style={{marginTop: '2.5rem', fontSize: '0.9rem', color: 'var(--ifm-color-emphasis-600)'}}>
+            Think this link should work?{' '}
+            <Link to="https://github.com/nomadicmehul/CloudCaptain/issues/new?template=bug_report.yml">
+              Report a broken link
+            </Link>
+            .
+          </p>
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
…404, image-zoom

- Enable sitemap.xml generation (classic preset, weekly/0.7)
- Enable blog RSS + Atom feeds via feedOptions
- Turn on showLastUpdateTime for docs (fetch-depth: 0 in deploy workflow)
- Scaffold commented gtag config for Google Analytics
- Add plugin-image-zoom for cheatsheets & diagrams
- Add GitHub issue forms (bug, feature, new resource) + config.yml with Discussions link
- Add pull request template with build + Co-Authored-By checklist
- Add SECURITY.md with private disclosure policy
- Add custom 404 page with terminal aesthetic and popular destinations