### PR TITLE
Add /progress dashboard + homepage Resume Reading widget

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -175,7 +175,6 @@ const config: Config = {
           label: 'Cloud Providers',
         },
         {to: '/journey', label: "Captain's Journey", position: 'left'},
-        {to: '/progress', label: '📖 Progress', position: 'left'},
         {to: '/contribute', label: 'Contribute', position: 'left'},
         {
           href: 'https://buymeacoffee.com/nomadicmehul',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -175,6 +175,7 @@ const config: Config = {
           label: 'Cloud Providers',
         },
         {to: '/journey', label: "Captain's Journey", position: 'left'},
+        {to: '/progress', label: '📖 Progress', position: 'left'},
         {to: '/contribute', label: 'Contribute', position: 'left'},
         {
           href: 'https://buymeacoffee.com/nomadicmehul',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -228,6 +228,7 @@ const config: Config = {
           title: 'More',
           items: [
             {label: 'Roadmap', to: '/docs/learning-paths/welcome'},
+            {label: '📖 Your Progress', to: '/progress'},
             {label: 'Blog', to: '/blog'},
             {label: '☕ Buy Me a Coffee', href: 'https://buymeacoffee.com/nomadicmehul'},
             {label: '❤️ Sponsor on GitHub', href: 'https://github.com/sponsors/nomadicmehul'},

--- a/website/src/components/Progress/ProgressByTool.tsx
+++ b/website/src/components/Progress/ProgressByTool.tsx
@@ -1,0 +1,178 @@
+import React, {useMemo, useState} from 'react';
+import Link from '@docusaurus/Link';
+import styles from './styles.module.css';
+import {CATEGORIES, classifyDoc} from './groupDocs';
+import type {ReadEntry} from './readProgress';
+
+export type DocSummary = {
+  pathname: string;
+  title: string;
+};
+
+type Props = {
+  allDocs: DocSummary[];
+  entries: ReadEntry[];
+};
+
+type Group = {
+  id: string;
+  label: string;
+  icon: string;
+  order: number;
+  docs: Array<{
+    pathname: string;
+    title: string;
+    entry: ReadEntry | undefined;
+    status: 'unread' | 'partial' | 'complete';
+  }>;
+  pagesTotal: number;
+  pagesTouched: number;
+  pagesComplete: number;
+};
+
+export default function ProgressByTool({allDocs, entries}: Props): JSX.Element {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const entriesByPath = useMemo(() => {
+    const m = new Map<string, ReadEntry>();
+    for (const e of entries) {
+      m.set(e.pathname, e);
+      // Also register normalized variants so sidebar links and doc paths match
+      m.set(e.pathname.replace(/\/$/, ''), e);
+      m.set(e.pathname.replace(/\/$/, '') + '/', e);
+    }
+    return m;
+  }, [entries]);
+
+  const groups = useMemo<Group[]>(() => {
+    const map = new Map<string, Group>();
+    for (const cat of CATEGORIES) {
+      map.set(cat.id, {
+        id: cat.id,
+        label: cat.label,
+        icon: cat.icon,
+        order: cat.order,
+        docs: [],
+        pagesTotal: 0,
+        pagesTouched: 0,
+        pagesComplete: 0,
+      });
+    }
+
+    for (const doc of allDocs) {
+      const cat = classifyDoc(doc.pathname);
+      if (!cat) continue;
+      const entry =
+        entriesByPath.get(doc.pathname) ??
+        entriesByPath.get(doc.pathname.replace(/\/$/, '')) ??
+        entriesByPath.get(doc.pathname.replace(/\/$/, '') + '/');
+      const status: 'unread' | 'partial' | 'complete' = !entry
+        ? 'unread'
+        : entry.isComplete
+          ? 'complete'
+          : 'partial';
+      const g = map.get(cat.id)!;
+      g.docs.push({pathname: doc.pathname, title: doc.title, entry, status});
+      g.pagesTotal += 1;
+      if (entry) g.pagesTouched += 1;
+      if (status === 'complete') g.pagesComplete += 1;
+    }
+
+    return Array.from(map.values())
+      .filter((g) => g.pagesTotal > 0)
+      .sort((a, b) => a.order - b.order);
+  }, [allDocs, entriesByPath]);
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  if (groups.length === 0) {
+    return (
+      <section className={styles.emptyState}>
+        <h2>No docs indexed</h2>
+        <p>The Docusaurus docs plugin isn't reporting any pages. Check your build.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.byTool} aria-label="Progress by tool and path">
+      <h2 className={styles.sectionHeading}>By Category</h2>
+      <div className={styles.groupList}>
+        {groups.map((g) => {
+          const pct = g.pagesTotal > 0 ? (g.pagesComplete / g.pagesTotal) * 100 : 0;
+          const touchedPct = g.pagesTotal > 0 ? (g.pagesTouched / g.pagesTotal) * 100 : 0;
+          const isOpen = expanded.has(g.id);
+          return (
+            <article
+              key={g.id}
+              className={`${styles.group} ${g.pagesComplete === g.pagesTotal && g.pagesTotal > 0 ? styles.groupDone : ''}`}>
+              <button
+                type="button"
+                className={styles.groupHeader}
+                onClick={() => toggle(g.id)}
+                aria-expanded={isOpen}>
+                <span className={styles.groupIcon} aria-hidden="true">
+                  {g.icon}
+                </span>
+                <div className={styles.groupMeta}>
+                  <span className={styles.groupLabel}>{g.label}</span>
+                  <span className={styles.groupSubtitle}>
+                    {g.pagesComplete} / {g.pagesTotal} pages complete
+                    {g.pagesTouched > g.pagesComplete && (
+                      <> · {g.pagesTouched - g.pagesComplete} in progress</>
+                    )}
+                  </span>
+                </div>
+                <div className={styles.groupBarWrap} aria-hidden="true">
+                  <div className={styles.groupBarTouched} style={{width: `${touchedPct}%`}} />
+                  <div className={styles.groupBarComplete} style={{width: `${pct}%`}} />
+                </div>
+                <span className={styles.groupChevron} aria-hidden="true">
+                  {isOpen ? '▾' : '▸'}
+                </span>
+              </button>
+
+              {isOpen && (
+                <ul className={styles.docList}>
+                  {g.docs
+                    .slice()
+                    .sort((a, b) => a.title.localeCompare(b.title))
+                    .map((doc) => (
+                      <li key={doc.pathname} className={`${styles.docRow} ${styles[`docRow_${doc.status}`]}`}>
+                        <span className={styles.docStatus} aria-hidden="true">
+                          {doc.status === 'complete'
+                            ? '●'
+                            : doc.status === 'partial'
+                              ? '◐'
+                              : '○'}
+                        </span>
+                        <Link to={doc.pathname} className={styles.docLink}>
+                          {doc.title}
+                        </Link>
+                        {doc.entry && doc.entry.totalSections ? (
+                          <span className={styles.docMeta}>
+                            {doc.entry.readCount} / {doc.entry.totalSections}
+                          </span>
+                        ) : doc.entry ? (
+                          <span className={styles.docMeta}>{doc.entry.readCount} read</span>
+                        ) : (
+                          <span className={styles.docMetaMuted}>not started</span>
+                        )}
+                      </li>
+                    ))}
+                </ul>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Progress/ProgressControls.tsx
+++ b/website/src/components/Progress/ProgressControls.tsx
@@ -1,0 +1,214 @@
+import React, {useRef, useState} from 'react';
+import styles from './styles.module.css';
+import {
+  clearAllReadEntries,
+  exportReadEntries,
+  importReadEntries,
+} from './readProgress';
+import {hasDemoSeed, seedDemoProgress, unseedDemoProgress} from './seedDemo';
+
+type Props = {
+  onChange: () => void;
+  hasEntries: boolean;
+};
+
+export default function ProgressControls({onChange, hasEntries}: Props): JSX.Element {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [confirmReset, setConfirmReset] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
+  const [seeded, setSeeded] = useState<boolean>(() => hasDemoSeed());
+
+  const flash = (m: string) => {
+    setMessage(m);
+    window.setTimeout(() => setMessage(null), 4000);
+  };
+
+  const doExport = () => {
+    const payload = exportReadEntries();
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const today = new Date().toISOString().slice(0, 10);
+    a.download = `cloudcaptain-progress-${today}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+    flash(`Exported ${Object.keys(payload.entries).length} entries.`);
+  };
+
+  const doImport = (mode: 'merge' | 'replace') => {
+    const input = fileInputRef.current;
+    if (!input) return;
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const parsed = JSON.parse(String(reader.result));
+          const {imported, skipped, errors} = importReadEntries(parsed, mode);
+          if (errors.length) flash(`Imported ${imported}, skipped ${skipped}. Errors: ${errors[0]}`);
+          else flash(`Imported ${imported} entries (skipped ${skipped}).`);
+          onChange();
+        } catch (e) {
+          flash(`Import failed: ${(e as Error).message}`);
+        }
+      };
+      reader.readAsText(file);
+      input.value = '';
+    };
+    input.click();
+  };
+
+  const doReset = () => {
+    if (confirmText !== 'DELETE') {
+      flash('Type DELETE in the confirmation box to proceed.');
+      return;
+    }
+    const n = clearAllReadEntries();
+    setConfirmReset(false);
+    setConfirmText('');
+    setSeeded(false);
+    flash(`Removed ${n} read entries.`);
+    onChange();
+  };
+
+  const doSeed = () => {
+    const {created, skipped} = seedDemoProgress();
+    setSeeded(true);
+    flash(`Seeded ${created} demo entries${skipped ? ` (skipped ${skipped} existing)` : ''}.`);
+    onChange();
+  };
+
+  const doUnseed = () => {
+    const n = unseedDemoProgress();
+    setSeeded(false);
+    flash(`Removed ${n} demo entries.`);
+    onChange();
+  };
+
+  return (
+    <section className={styles.controls} aria-label="Progress controls">
+      <h2 className={styles.sectionHeading}>Manage</h2>
+
+      <div className={styles.controlsGrid}>
+        <div className={styles.controlCard}>
+          <h3 className={styles.controlCardTitle}>⬇ Export</h3>
+          <p className={styles.controlCardBody}>
+            Download your read-progress as JSON. Safe to share or back up.
+          </p>
+          <button
+            type="button"
+            className={styles.controlBtn}
+            disabled={!hasEntries}
+            onClick={doExport}>
+            Export as JSON
+          </button>
+        </div>
+
+        <div className={styles.controlCard}>
+          <h3 className={styles.controlCardTitle}>⬆ Import</h3>
+          <p className={styles.controlCardBody}>
+            Merge or replace read-progress from a previously exported JSON file.
+          </p>
+          <div className={styles.controlBtnRow}>
+            <button type="button" className={styles.controlBtn} onClick={() => doImport('merge')}>
+              Merge
+            </button>
+            <button
+              type="button"
+              className={`${styles.controlBtn} ${styles.controlBtnGhost}`}
+              onClick={() => doImport('replace')}>
+              Replace all
+            </button>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json,.json"
+            hidden
+            aria-hidden="true"
+          />
+        </div>
+
+        <div className={styles.controlCard}>
+          <h3 className={styles.controlCardTitle}>🪄 Demo data</h3>
+          <p className={styles.controlCardBody}>
+            Pre-fill the dashboard with sample progress so you can see what it looks like. Skips any
+            pages where you already have real progress.
+          </p>
+          {seeded ? (
+            <button type="button" className={styles.controlBtn} onClick={doUnseed}>
+              Remove demo data
+            </button>
+          ) : (
+            <button type="button" className={styles.controlBtn} onClick={doSeed}>
+              Seed demo data
+            </button>
+          )}
+        </div>
+
+        <div className={`${styles.controlCard} ${styles.controlCardDanger}`}>
+          <h3 className={styles.controlCardTitle}>↻ Reset</h3>
+          <p className={styles.controlCardBody}>
+            Deletes every read-progress entry from this browser. Irreversible.
+          </p>
+          {confirmReset ? (
+            <div className={styles.controlConfirm}>
+              <input
+                type="text"
+                className={styles.controlInput}
+                placeholder="Type DELETE to confirm"
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                autoFocus
+              />
+              <div className={styles.controlBtnRow}>
+                <button
+                  type="button"
+                  className={`${styles.controlBtn} ${styles.controlBtnDanger}`}
+                  disabled={confirmText !== 'DELETE'}
+                  onClick={doReset}>
+                  Delete all
+                </button>
+                <button
+                  type="button"
+                  className={`${styles.controlBtn} ${styles.controlBtnGhost}`}
+                  onClick={() => {
+                    setConfirmReset(false);
+                    setConfirmText('');
+                  }}>
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className={`${styles.controlBtn} ${styles.controlBtnDanger}`}
+              disabled={!hasEntries}
+              onClick={() => setConfirmReset(true)}>
+              Reset everything
+            </button>
+          )}
+        </div>
+      </div>
+
+      {message && (
+        <div className={styles.controlsMessage} role="status" aria-live="polite">
+          {message}
+        </div>
+      )}
+
+      <p className={styles.privacyNote}>
+        🔒 Progress is stored in your browser's localStorage only. CloudCaptain's servers never
+        receive it. Clearing your browser data erases it.
+      </p>
+    </section>
+  );
+}

--- a/website/src/components/Progress/ProgressHero.tsx
+++ b/website/src/components/Progress/ProgressHero.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+type Props = {
+  pagesTouched: number;
+  pagesComplete: number;
+  sectionsRead: number;
+  lastUpdated: number | undefined;
+};
+
+function relativeTime(ts: number | undefined): string {
+  if (!ts) return 'never';
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return 'just now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} min ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} h ago`;
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)} d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+export default function ProgressHero({
+  pagesTouched,
+  pagesComplete,
+  sectionsRead,
+  lastUpdated,
+}: Props): JSX.Element {
+  return (
+    <section className={styles.hero} aria-label="Progress summary">
+      <div className={styles.heroTitleRow}>
+        <h1 className={styles.heroTitle}>
+          <span className={styles.heroEmoji}>📖</span> Your Progress
+        </h1>
+        <span className={styles.heroSubtitle}>
+          Tracked privately in this browser via Captain's Bridge reading mode.
+        </span>
+      </div>
+
+      <div className={styles.heroStats}>
+        <div className={styles.statCard}>
+          <span className={styles.statLabel}>Sections read</span>
+          <span className={styles.statValue}>{sectionsRead}</span>
+          <span className={styles.statFoot}>across your learning journey</span>
+        </div>
+        <div className={styles.statCard}>
+          <span className={styles.statLabel}>Pages touched</span>
+          <span className={styles.statValue}>{pagesTouched}</span>
+          <span className={styles.statFoot}>started but not complete</span>
+        </div>
+        <div className={styles.statCard}>
+          <span className={styles.statLabel}>Pages complete</span>
+          <span className={styles.statValue}>{pagesComplete}</span>
+          <span className={styles.statFoot}>🏁 every section marked</span>
+        </div>
+        <div className={styles.statCard}>
+          <span className={styles.statLabel}>Last active</span>
+          <span className={styles.statValueSmall}>{relativeTime(lastUpdated)}</span>
+          <span className={styles.statFoot}>
+            {lastUpdated ? new Date(lastUpdated).toLocaleString() : '—'}
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Progress/ResumeReadingWidget.tsx
+++ b/website/src/components/Progress/ResumeReadingWidget.tsx
@@ -1,0 +1,126 @@
+/**
+ * ResumeReadingWidget — homepage banner that surfaces the user's top 3
+ * in-progress docs. Renders nothing when there's no read-progress data,
+ * so first-time visitors see a clean hero.
+ *
+ * Client-only: gated by BrowserOnly in the parent to avoid SSR flash
+ * (localStorage is unavailable on the server).
+ */
+import React, {useEffect, useState} from 'react';
+import Link from '@docusaurus/Link';
+import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
+import {getAllReadEntries, type ReadEntry} from './readProgress';
+import styles from './resumeWidget.module.css';
+
+type EnrichedEntry = ReadEntry & {
+  title: string;
+  percent: number;
+};
+
+function relativeShort(ts: number | undefined): string {
+  if (!ts) return '';
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return 'just now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+  return `${Math.floor(diff / (7 * 86_400_000))}w ago`;
+}
+
+function humanizePath(path: string): string {
+  const last = path.split('/').filter(Boolean).pop() ?? path;
+  return last
+    .replace(/^index$/, 'Overview')
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function ResumeReadingWidget(): JSX.Element | null {
+  const allDocsData = useAllDocsData();
+  const [entries, setEntries] = useState<ReadEntry[]>([]);
+
+  useEffect(() => {
+    const refresh = () => setEntries(getAllReadEntries());
+    refresh();
+    window.addEventListener('cc-bridge-read-change', refresh);
+    window.addEventListener('storage', refresh);
+    return () => {
+      window.removeEventListener('cc-bridge-read-change', refresh);
+      window.removeEventListener('storage', refresh);
+    };
+  }, []);
+
+  const topInProgress = React.useMemo<EnrichedEntry[]>(() => {
+    // Build title index from all indexed docs
+    const titleByPath = new Map<string, string>();
+    for (const pluginId of Object.keys(allDocsData)) {
+      const plugin = allDocsData[pluginId];
+      for (const version of plugin?.versions ?? []) {
+        for (const doc of version.docs ?? []) {
+          if (!doc || typeof doc.path !== 'string') continue;
+          const label =
+            // @ts-expect-error - Docusaurus may expose a label on doc; fall through otherwise
+            doc.label || humanizePath(doc.id || doc.path);
+          titleByPath.set(doc.path, label);
+          titleByPath.set(doc.path.replace(/\/$/, ''), label);
+          titleByPath.set(doc.path.replace(/\/$/, '') + '/', label);
+        }
+      }
+    }
+
+    return entries
+      .filter((e) => e.readCount > 0 && !e.isComplete)
+      .map((e) => {
+        const total = e.totalSections && e.totalSections > 0 ? e.totalSections : e.readCount;
+        const percent = Math.min(100, Math.round((e.readCount / total) * 100));
+        const title =
+          titleByPath.get(e.pathname) ??
+          titleByPath.get(e.pathname.replace(/\/$/, '')) ??
+          humanizePath(e.pathname);
+        return {...e, title, percent};
+      })
+      .sort((a, b) => (b.lastUpdated ?? 0) - (a.lastUpdated ?? 0))
+      .slice(0, 3);
+  }, [entries, allDocsData]);
+
+  if (topInProgress.length === 0) return null;
+
+  return (
+    <section className={styles.widget} aria-label="Resume reading">
+      <div className={styles.widgetInner}>
+        <header className={styles.widgetHeader}>
+          <div>
+            <span className={styles.widgetKicker}>⚓ CAPTAIN'S LOG</span>
+            <h2 className={styles.widgetTitle}>Resume where you left off</h2>
+          </div>
+          <Link to="/progress" className={styles.widgetAll}>
+            View all progress →
+          </Link>
+        </header>
+
+        <ul className={styles.resumeList}>
+          {topInProgress.map((e) => (
+            <li key={e.pathname} className={styles.resumeItem}>
+              <Link to={e.pathname} className={styles.resumeLink}>
+                <div className={styles.resumeTopRow}>
+                  <span className={styles.resumeTitle}>{e.title}</span>
+                  <span className={styles.resumeMeta}>
+                    {e.readCount}
+                    {e.totalSections ? ` / ${e.totalSections}` : ''} · {relativeShort(e.lastUpdated)}
+                  </span>
+                </div>
+                <div className={styles.resumeBar} aria-hidden="true">
+                  <div className={styles.resumeBarFill} style={{width: `${e.percent}%`}} />
+                </div>
+                <div className={styles.resumeBottomRow}>
+                  <span className={styles.resumePath}>{e.pathname}</span>
+                  <span className={styles.resumeContinue}>Continue →</span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Progress/groupDocs.ts
+++ b/website/src/components/Progress/groupDocs.ts
@@ -1,0 +1,88 @@
+/**
+ * groupDocs — classify every doc path into a category/tool bucket so the
+ * /progress dashboard can show per-tool completion.
+ *
+ * The full list of docs comes from Docusaurus's useAllDocsData(); this file
+ * only defines the grouping rules (pathname regex → category label + icon).
+ */
+
+export type Category = {
+  id: string;
+  label: string;
+  icon: string;
+  /** Preferred display order (lower = higher) */
+  order: number;
+  match: RegExp;
+};
+
+export const CATEGORIES: Category[] = [
+  // Learning paths
+  {
+    id: 'path-devops',
+    label: 'DevOps Path',
+    icon: '🚀',
+    order: 10,
+    match: /^\/docs\/learning-paths\/devops(\/|$)/,
+  },
+  {
+    id: 'path-linux',
+    label: 'Linux Master',
+    icon: '🐧',
+    order: 11,
+    match: /^\/docs\/learning-paths\/linux-master(\/|$)/,
+  },
+  {
+    id: 'path-aiml',
+    label: 'AI / ML Ops',
+    icon: '🤖',
+    order: 12,
+    match: /^\/docs\/learning-paths\/ai-ml(\/|$)/,
+  },
+  {
+    id: 'path-other',
+    label: 'Other Learning Paths',
+    icon: '📚',
+    order: 13,
+    match: /^\/docs\/learning-paths\//,
+  },
+
+  // Tools
+  {id: 'tool-docker',     label: 'Docker',     icon: '🐳', order: 20, match: /^\/docs\/tools\/docker(\/|$)/},
+  {id: 'tool-kubernetes', label: 'Kubernetes', icon: '☸️',  order: 21, match: /^\/docs\/tools\/kubernetes(\/|$)/},
+  {id: 'tool-terraform',  label: 'Terraform',  icon: '🏗️',  order: 22, match: /^\/docs\/tools\/terraform(\/|$)/},
+  {id: 'tool-ansible',    label: 'Ansible',    icon: '🔧', order: 23, match: /^\/docs\/tools\/ansible(\/|$)/},
+  {id: 'tool-helm',       label: 'Helm',       icon: '⎈',  order: 24, match: /^\/docs\/tools\/helm(\/|$)/},
+  {id: 'tool-linux',      label: 'Linux',      icon: '🐧', order: 25, match: /^\/docs\/tools\/linux(\/|$)/},
+  {id: 'tool-bash',       label: 'Bash',       icon: '💻', order: 26, match: /^\/docs\/tools\/bash(\/|$)/},
+  {id: 'tool-python',     label: 'Python',     icon: '🐍', order: 27, match: /^\/docs\/tools\/python(\/|$)/},
+  {id: 'tool-git',        label: 'Git',        icon: '🔀', order: 28, match: /^\/docs\/tools\/git(\/|$)/},
+  {id: 'tool-yaml',       label: 'YAML',       icon: '📄', order: 29, match: /^\/docs\/tools\/yaml(\/|$)/},
+  {id: 'tool-other',      label: 'Other Tools',icon: '🔧', order: 30, match: /^\/docs\/tools\//},
+
+  // Cloud
+  {id: 'cloud-aws',   label: 'AWS',   icon: '☁️', order: 40, match: /^\/docs\/cloud\/aws(\/|$)/},
+  {id: 'cloud-azure', label: 'Azure', icon: '🌩️', order: 41, match: /^\/docs\/cloud\/azure(\/|$)/},
+  {id: 'cloud-gcp',   label: 'GCP',   icon: '🌥️', order: 42, match: /^\/docs\/cloud\/gcp(\/|$)/},
+  {id: 'cloud-other', label: 'Other Cloud', icon: '☁️', order: 43, match: /^\/docs\/cloud\//},
+
+  // Interview prep + catch-all
+  {id: 'interview', label: 'Interview Prep', icon: '🎯', order: 50, match: /^\/docs\/interview-prep(\/|$)/},
+  {id: 'other',     label: 'Other Docs',     icon: '📄', order: 99, match: /^\/docs\//},
+];
+
+export function classifyDoc(pathname: string): Category | null {
+  for (const cat of CATEGORIES) {
+    if (cat.match.test(pathname)) return cat;
+  }
+  return null;
+}
+
+/**
+ * Normalize a pathname for matching against localStorage keys.
+ * Docusaurus may or may not include trailing slashes depending on config;
+ * we compare both variants.
+ */
+export function normalizeCandidates(pathname: string): string[] {
+  const trimmed = pathname.replace(/\/$/, '');
+  return [pathname, trimmed, `${trimmed}/`];
+}

--- a/website/src/components/Progress/readProgress.ts
+++ b/website/src/components/Progress/readProgress.ts
@@ -1,0 +1,136 @@
+/**
+ * readProgress — localStorage reader for the /progress dashboard.
+ *
+ * Mirrors the contract written by the Captain's Bridge reader
+ * (website/src/components/CaptainsBridge/useReadProgress.ts). Duplicated
+ * here so the /progress page can ship independently of the Bridge branch.
+ * When both are merged they share the same key schema:
+ *
+ *   key   = `cloudcaptain.bridge.read.{pathname}`
+ *   value = JSON: { readSections: string[], totalSections?: number,
+ *                   lastUpdated?: number }
+ */
+const STORAGE_PREFIX = 'cloudcaptain.bridge.read.';
+
+export type ReadEntry = {
+  pathname: string;
+  readSections: string[];
+  readCount: number;
+  totalSections?: number;
+  lastUpdated?: number;
+  isComplete: boolean;
+};
+
+export function getAllReadEntries(): ReadEntry[] {
+  if (typeof localStorage === 'undefined') return [];
+  const out: ReadEntry[] = [];
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const k = localStorage.key(i);
+    if (!k || !k.startsWith(STORAGE_PREFIX)) continue;
+    const pathname = k.slice(STORAGE_PREFIX.length);
+    const raw = localStorage.getItem(k);
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw);
+      const readSections: string[] = Array.isArray(parsed.readSections)
+        ? parsed.readSections
+        : [];
+      const readCount = readSections.length;
+      if (readCount === 0 && !parsed.totalSections) continue;
+      const totalSections: number | undefined = parsed.totalSections;
+      const isComplete =
+        typeof totalSections === 'number' && totalSections > 0 && readCount >= totalSections;
+      out.push({
+        pathname,
+        readSections,
+        readCount,
+        totalSections,
+        lastUpdated: parsed.lastUpdated,
+        isComplete,
+      });
+    } catch {}
+  }
+  return out;
+}
+
+export function clearAllReadEntries(): number {
+  if (typeof localStorage === 'undefined') return 0;
+  const toRemove: string[] = [];
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const k = localStorage.key(i);
+    if (k && k.startsWith(STORAGE_PREFIX)) toRemove.push(k);
+  }
+  toRemove.forEach((k) => localStorage.removeItem(k));
+  window.dispatchEvent(new CustomEvent('cc-bridge-read-change'));
+  return toRemove.length;
+}
+
+export type ExportPayload = {
+  version: 1;
+  exportedAt: string;
+  appliedFrom: string;
+  entries: Record<string, {
+    readSections: string[];
+    totalSections?: number;
+    lastUpdated?: number;
+  }>;
+};
+
+export function exportReadEntries(): ExportPayload {
+  const entries = getAllReadEntries();
+  const payload: ExportPayload = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    appliedFrom: typeof window !== 'undefined' ? window.location.origin : 'unknown',
+    entries: {},
+  };
+  for (const e of entries) {
+    payload.entries[e.pathname] = {
+      readSections: e.readSections,
+      totalSections: e.totalSections,
+      lastUpdated: e.lastUpdated,
+    };
+  }
+  return payload;
+}
+
+export function importReadEntries(
+  payload: unknown,
+  mode: 'merge' | 'replace' = 'merge'
+): {imported: number; skipped: number; errors: string[]} {
+  const errors: string[] = [];
+  if (!payload || typeof payload !== 'object') {
+    return {imported: 0, skipped: 0, errors: ['Invalid payload: not an object.']};
+  }
+  const p = payload as ExportPayload;
+  if (p.version !== 1 || !p.entries || typeof p.entries !== 'object') {
+    return {
+      imported: 0,
+      skipped: 0,
+      errors: ['Invalid payload: missing version:1 or entries map.'],
+    };
+  }
+  if (mode === 'replace') clearAllReadEntries();
+  let imported = 0;
+  let skipped = 0;
+  for (const [pathname, entry] of Object.entries(p.entries)) {
+    if (!pathname.startsWith('/')) {
+      skipped += 1;
+      continue;
+    }
+    try {
+      const toStore = {
+        readSections: Array.isArray(entry.readSections) ? entry.readSections : [],
+        totalSections: entry.totalSections,
+        lastUpdated: entry.lastUpdated ?? Date.now(),
+      };
+      localStorage.setItem(STORAGE_PREFIX + pathname, JSON.stringify(toStore));
+      imported += 1;
+    } catch (e) {
+      errors.push(`Failed to import ${pathname}: ${(e as Error).message}`);
+      skipped += 1;
+    }
+  }
+  window.dispatchEvent(new CustomEvent('cc-bridge-read-change'));
+  return {imported, skipped, errors};
+}

--- a/website/src/components/Progress/resumeWidget.module.css
+++ b/website/src/components/Progress/resumeWidget.module.css
@@ -1,0 +1,173 @@
+/* =========================================================================
+   ResumeReadingWidget — homepage "Captain's Log" for in-progress docs
+   ========================================================================= */
+
+.widget {
+  padding: 2.5rem 1rem 1rem;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(30, 155, 215, 0.035) 40%,
+    transparent 100%
+  );
+}
+
+.widgetInner {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  background: var(--ifm-background-surface-color, #fff);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 14px;
+  box-shadow: 0 4px 24px rgba(10, 22, 40, 0.06);
+}
+
+.widgetHeader {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+.widgetKicker {
+  display: inline-block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  color: var(--ifm-color-primary);
+  margin-bottom: 2px;
+}
+.widgetTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 800;
+}
+.widgetAll {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+.widgetAll:hover {
+  color: var(--ifm-color-primary-darker);
+  text-decoration: underline;
+}
+
+.resumeList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 10px;
+}
+
+.resumeItem {
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 10px;
+  overflow: hidden;
+  transition: all 0.15s ease;
+}
+.resumeItem:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(30, 155, 215, 0.12);
+}
+
+.resumeLink {
+  display: block;
+  padding: 14px 16px;
+  color: inherit;
+  text-decoration: none;
+}
+.resumeLink:hover {
+  text-decoration: none;
+  color: inherit;
+}
+
+.resumeTopRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.resumeTitle {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ifm-color-content);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 70%;
+}
+.resumeMeta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-600);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.resumeBar {
+  height: 4px;
+  background: var(--ifm-color-emphasis-200);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+.resumeBarFill {
+  height: 100%;
+  background: linear-gradient(90deg, #10b981, #38bdf8);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+  box-shadow: 0 0 8px rgba(16, 185, 129, 0.4);
+}
+
+.resumeBottomRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.resumePath {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-500);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 60%;
+}
+.resumeContinue {
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+/* Dark mode adjustments */
+[data-theme='dark'] .widgetInner {
+  background: rgba(15, 30, 51, 0.5);
+  border-color: rgba(56, 189, 248, 0.15);
+}
+[data-theme='dark'] .resumeItem {
+  background: rgba(10, 22, 40, 0.5);
+  border-color: rgba(56, 189, 248, 0.1);
+}
+[data-theme='dark'] .resumeItem:hover {
+  background: rgba(10, 22, 40, 0.7);
+}
+
+@media (max-width: 600px) {
+  .widget { padding: 1.5rem 0.75rem 0.5rem; }
+  .widgetInner { padding: 1rem; }
+  .resumeTitle { max-width: 100%; }
+}

--- a/website/src/components/Progress/seedDemo.ts
+++ b/website/src/components/Progress/seedDemo.ts
@@ -1,0 +1,134 @@
+/**
+ * seedDemo — writes a small set of synthetic read-progress entries into
+ * localStorage so /progress can be demoed before users actually read docs.
+ *
+ * Safety:
+ *   - Refuses to overwrite keys that already have non-zero readCount (we
+ *     never clobber real progress).
+ *   - Marks seeded entries with lastUpdated = recent timestamps spread
+ *     across the last 10 days so the dashboard looks realistic.
+ *   - Reversible via a dedicated unseed() that removes ONLY the keys we
+ *     wrote in this seed pass (tracked in a dedicated meta key).
+ */
+const STORAGE_PREFIX = 'cloudcaptain.bridge.read.';
+const SEED_META_KEY = 'cloudcaptain.bridge.demo-seed';
+
+type SeedEntry = {
+  pathname: string;
+  readSections: string[];
+  totalSections: number;
+  daysAgo: number;
+};
+
+const DEMO_ENTRIES: SeedEntry[] = [
+  {
+    pathname: '/docs/tools/docker/fundamentals',
+    readSections: ['what-is-docker', 'containers-vs-virtual-machines', 'docker-architecture'],
+    totalSections: 8,
+    daysAgo: 0,
+  },
+  {
+    pathname: '/docs/tools/docker/',
+    readSections: ['overview'],
+    totalSections: 1,
+    daysAgo: 0,
+  },
+  {
+    pathname: '/docs/tools/docker/cheatsheet',
+    readSections: ['basics', 'images', 'containers', 'networking', 'volumes'],
+    totalSections: 5,
+    daysAgo: 2,
+  },
+  {
+    pathname: '/docs/tools/kubernetes/fundamentals',
+    readSections: ['what-is-kubernetes', 'architecture'],
+    totalSections: 10,
+    daysAgo: 3,
+  },
+  {
+    pathname: '/docs/learning-paths/devops',
+    readSections: ['intro', 'linux-fundamentals', 'version-control'],
+    totalSections: 8,
+    daysAgo: 4,
+  },
+  {
+    pathname: '/docs/tools/terraform/fundamentals',
+    readSections: ['what-is-terraform'],
+    totalSections: 6,
+    daysAgo: 6,
+  },
+  {
+    pathname: '/docs/tools/linux/fundamentals',
+    readSections: ['filesystem', 'permissions', 'processes', 'shell-basics'],
+    totalSections: 4,
+    daysAgo: 7,
+  },
+  {
+    pathname: '/docs/tools/git/fundamentals',
+    readSections: ['intro', 'basic-commands'],
+    totalSections: 5,
+    daysAgo: 9,
+  },
+];
+
+export function seedDemoProgress(): {created: number; skipped: number} {
+  if (typeof localStorage === 'undefined') return {created: 0, skipped: 0};
+  let created = 0;
+  let skipped = 0;
+  const seededKeys: string[] = [];
+  const now = Date.now();
+  for (const seed of DEMO_ENTRIES) {
+    const key = STORAGE_PREFIX + seed.pathname;
+    try {
+      const existing = localStorage.getItem(key);
+      if (existing) {
+        try {
+          const parsed = JSON.parse(existing);
+          if (Array.isArray(parsed.readSections) && parsed.readSections.length > 0) {
+            skipped += 1;
+            continue;
+          }
+        } catch {}
+      }
+      const lastUpdated = now - seed.daysAgo * 86_400_000 - Math.floor(Math.random() * 3_600_000);
+      localStorage.setItem(
+        key,
+        JSON.stringify({
+          readSections: seed.readSections,
+          totalSections: seed.totalSections,
+          lastUpdated,
+        })
+      );
+      seededKeys.push(key);
+      created += 1;
+    } catch {
+      skipped += 1;
+    }
+  }
+  try {
+    localStorage.setItem(SEED_META_KEY, JSON.stringify({keys: seededKeys, at: now}));
+  } catch {}
+  window.dispatchEvent(new CustomEvent('cc-bridge-read-change'));
+  return {created, skipped};
+}
+
+export function unseedDemoProgress(): number {
+  if (typeof localStorage === 'undefined') return 0;
+  try {
+    const raw = localStorage.getItem(SEED_META_KEY);
+    if (!raw) return 0;
+    const meta = JSON.parse(raw) as {keys: string[]};
+    const keys = Array.isArray(meta.keys) ? meta.keys : [];
+    keys.forEach((k) => localStorage.removeItem(k));
+    localStorage.removeItem(SEED_META_KEY);
+    window.dispatchEvent(new CustomEvent('cc-bridge-read-change'));
+    return keys.length;
+  } catch {
+    return 0;
+  }
+}
+
+export function hasDemoSeed(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  return localStorage.getItem(SEED_META_KEY) !== null;
+}

--- a/website/src/components/Progress/styles.module.css
+++ b/website/src/components/Progress/styles.module.css
@@ -1,0 +1,367 @@
+/* =========================================================================
+   /progress — cross-page reading dashboard
+   ========================================================================= */
+
+.page {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+.sectionHeading {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-700);
+  margin: 2rem 0 1rem;
+}
+
+/* Hero ----------------------------------------------------------------- */
+.hero {
+  background: linear-gradient(135deg, rgba(30, 155, 215, 0.08), rgba(16, 185, 129, 0.06));
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 1.5rem;
+}
+.heroTitleRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 1.25rem;
+}
+.heroTitle {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.heroEmoji { font-size: 2rem; }
+.heroSubtitle {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.9rem;
+}
+
+.heroStats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+.statCard {
+  background: var(--ifm-background-surface-color, #fff);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 88px;
+}
+.statLabel {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+}
+.statValue {
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.1;
+  color: var(--ifm-color-primary);
+  font-variant-numeric: tabular-nums;
+}
+.statValueSmall {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+}
+.statFoot {
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-500);
+}
+
+/* Empty state ----------------------------------------------------------- */
+.emptyState {
+  background: var(--ifm-background-surface-color, #fff);
+  border: 1px dashed var(--ifm-color-emphasis-400);
+  border-radius: 14px;
+  padding: 2rem;
+  margin: 1.5rem 0;
+  text-align: center;
+}
+.emptyState h2 { margin: 0 0 0.75rem; font-size: 1.25rem; }
+.emptyState p {
+  color: var(--ifm-color-emphasis-600);
+  margin: 0 0 1rem;
+  line-height: 1.6;
+}
+.emptyActions {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin: 1rem 0 0.75rem;
+}
+.emptyHint {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-500);
+  margin-top: 1rem !important;
+}
+
+/* ByTool ---------------------------------------------------------------- */
+.byTool { margin: 1rem 0 2rem; }
+
+.groupList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.group {
+  background: var(--ifm-background-surface-color, #fff);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  overflow: hidden;
+  transition: border-color 0.15s ease;
+}
+.group:hover { border-color: var(--ifm-color-primary); }
+.groupDone {
+  border-color: #10b981;
+  background: linear-gradient(90deg, rgba(16, 185, 129, 0.05), transparent);
+}
+
+.groupHeader {
+  display: grid;
+  grid-template-columns: auto 1fr 200px auto;
+  gap: 14px;
+  align-items: center;
+  padding: 14px 18px;
+  background: transparent;
+  border: 0;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+}
+.groupHeader:hover { background: var(--ifm-color-emphasis-100); }
+
+.groupIcon { font-size: 22px; }
+.groupMeta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.groupLabel {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+.groupSubtitle {
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.groupBarWrap {
+  position: relative;
+  height: 8px;
+  background: var(--ifm-color-emphasis-200);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.groupBarTouched {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: rgba(56, 189, 248, 0.5);
+  transition: width 0.3s ease;
+}
+.groupBarComplete {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: linear-gradient(90deg, #10b981, #38bdf8);
+  transition: width 0.3s ease;
+  box-shadow: 0 0 6px rgba(16, 185, 129, 0.4);
+}
+
+.groupChevron {
+  color: var(--ifm-color-emphasis-600);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.1rem;
+  width: 16px;
+  text-align: center;
+}
+
+.docList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-color-emphasis-100);
+}
+.docRow {
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  font-size: 0.9rem;
+}
+.docRow:last-child { border-bottom: 0; }
+.docStatus {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
+  text-align: center;
+}
+.docRow_unread .docStatus   { color: var(--ifm-color-emphasis-400); }
+.docRow_partial .docStatus  { color: #38bdf8; }
+.docRow_complete .docStatus { color: #10b981; text-shadow: 0 0 6px rgba(16,185,129,0.4); }
+.docRow_complete .docLink   { text-decoration: line-through; text-decoration-color: rgba(16,185,129,0.4); }
+.docLink {
+  color: var(--ifm-color-content);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.docLink:hover { color: var(--ifm-color-primary); text-decoration: underline; }
+.docMeta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-700);
+  font-variant-numeric: tabular-nums;
+}
+.docMetaMuted {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-500);
+}
+
+/* Controls -------------------------------------------------------------- */
+.controls { margin-top: 1.5rem; }
+
+.controlsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.controlCard {
+  background: var(--ifm-background-surface-color, #fff);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.controlCardDanger {
+  border-color: rgba(239, 68, 68, 0.5);
+  background: linear-gradient(180deg, rgba(239, 68, 68, 0.05), transparent);
+}
+.controlCardTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+.controlCardBody {
+  font-size: 0.82rem;
+  color: var(--ifm-color-emphasis-600);
+  margin: 0;
+  line-height: 1.5;
+  min-height: 54px;
+}
+.controlBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  background: var(--ifm-color-primary);
+  color: #fff;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: all 0.15s ease;
+}
+.controlBtn:hover:not(:disabled) {
+  background: var(--ifm-color-primary-darker);
+  transform: translateY(-1px);
+}
+.controlBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.controlBtnGhost {
+  background: transparent;
+  color: var(--ifm-color-primary);
+  border: 1px solid var(--ifm-color-primary);
+}
+.controlBtnGhost:hover:not(:disabled) {
+  background: rgba(30, 155, 215, 0.08);
+  color: var(--ifm-color-primary-darker);
+}
+.controlBtnDanger {
+  background: #ef4444;
+}
+.controlBtnDanger:hover:not(:disabled) {
+  background: #dc2626;
+}
+.controlBtnRow {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.controlConfirm {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.controlInput {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  background: var(--ifm-background-surface-color, #fff);
+  color: var(--ifm-color-content);
+}
+.controlInput:focus {
+  outline: 2px solid #ef4444;
+  outline-offset: 2px;
+}
+
+.controlsMessage {
+  margin-top: 14px;
+  padding: 10px 14px;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  border-radius: 6px;
+  color: var(--ifm-color-primary-darker);
+  font-size: 0.85rem;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.privacyNote {
+  margin-top: 16px;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+  text-align: center;
+  padding: 12px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+}
+
+/* Responsive ------------------------------------------------------------ */
+@media (max-width: 768px) {
+  .groupHeader {
+    grid-template-columns: auto 1fr auto;
+  }
+  .groupBarWrap { display: none; }
+  .heroStats { grid-template-columns: repeat(2, 1fr); }
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import ResumeReadingWidget from '@site/src/components/Progress/ResumeReadingWidget';
 
 /* ─── Data (loaded from JSON — edit the JSON files to update content) ─── */
 import categories from '../data/categories.json';
@@ -563,6 +565,7 @@ export default function Home(): React.ReactElement {
       title={`${siteConfig.title} — Learn Cloud, DevOps & AI`}
       description="Open-source community learning platform for Cloud, DevOps, AI, and Operations. Free forever.">
       <HeroSection />
+      <BrowserOnly>{() => <ResumeReadingWidget />}</BrowserOnly>
       <StatsSection />
       <CategoriesSection />
       <LearningPathsSection />

--- a/website/src/pages/progress.tsx
+++ b/website/src/pages/progress.tsx
@@ -1,0 +1,161 @@
+/**
+ * /progress — cross-page reading-progress dashboard.
+ *
+ * Purely client-side. Reads localStorage entries written by Captain's Bridge
+ * (website/src/components/CaptainsBridge/useReadProgress.ts) and joins them
+ * with the full set of docs exposed by Docusaurus's useAllDocsData().
+ *
+ * SSR renders an empty skeleton; the real data fills in on the client. This
+ * avoids hydration mismatches (localStorage is not available on the server).
+ */
+import React, {useEffect, useMemo, useState} from 'react';
+import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import Link from '@docusaurus/Link';
+import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
+
+import ProgressHero from '@site/src/components/Progress/ProgressHero';
+import ProgressByTool, {
+  type DocSummary,
+} from '@site/src/components/Progress/ProgressByTool';
+import ProgressControls from '@site/src/components/Progress/ProgressControls';
+import {
+  getAllReadEntries,
+  type ReadEntry,
+} from '@site/src/components/Progress/readProgress';
+import styles from '@site/src/components/Progress/styles.module.css';
+
+function flattenDocs(allDocsData: ReturnType<typeof useAllDocsData>): DocSummary[] {
+  const out: DocSummary[] = [];
+  for (const pluginId of Object.keys(allDocsData)) {
+    const plugin = allDocsData[pluginId];
+    if (!plugin) continue;
+    const versions = plugin.versions ?? [];
+    for (const version of versions) {
+      for (const doc of version.docs ?? []) {
+        // Docusaurus doc shape: {id, path, sidebar}
+        if (!doc || typeof doc.path !== 'string') continue;
+        out.push({
+          pathname: doc.path,
+          title:
+            // @ts-expect-error - Docusaurus exposes sidebar label via id heuristics;
+            // prefer the prettier segment if provided, else derive from path.
+            doc.label || humanizePath(doc.id || doc.path),
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function humanizePath(idOrPath: string): string {
+  const last = idOrPath.split('/').filter(Boolean).pop() || idOrPath;
+  return last
+    .replace(/^index$/, 'Overview')
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function ProgressPageInner(): JSX.Element {
+  const allDocsData = useAllDocsData();
+  const allDocs = useMemo(() => flattenDocs(allDocsData), [allDocsData]);
+
+  const [entries, setEntries] = useState<ReadEntry[]>([]);
+  const [tick, setTick] = useState(0);
+
+  const refresh = () => setTick((n) => n + 1);
+
+  useEffect(() => {
+    setEntries(getAllReadEntries());
+  }, [tick]);
+
+  // React to progress changes from Bridge (same tab) and other tabs
+  useEffect(() => {
+    const handler = () => refresh();
+    window.addEventListener('cc-bridge-read-change', handler);
+    window.addEventListener('storage', handler);
+    return () => {
+      window.removeEventListener('cc-bridge-read-change', handler);
+      window.removeEventListener('storage', handler);
+    };
+  }, []);
+
+  const {pagesTouched, pagesComplete, sectionsRead, lastUpdated} = useMemo(() => {
+    let touched = 0;
+    let complete = 0;
+    let sections = 0;
+    let last: number | undefined;
+    for (const e of entries) {
+      if (e.readCount > 0) touched += 1;
+      if (e.isComplete) complete += 1;
+      sections += e.readCount;
+      if (e.lastUpdated && (!last || e.lastUpdated > last)) last = e.lastUpdated;
+    }
+    return {
+      pagesTouched: touched,
+      pagesComplete: complete,
+      sectionsRead: sections,
+      lastUpdated: last,
+    };
+  }, [entries]);
+
+  const hasEntries = entries.length > 0;
+
+  return (
+    <main className={styles.page}>
+      <ProgressHero
+        pagesTouched={pagesTouched}
+        pagesComplete={pagesComplete}
+        sectionsRead={sectionsRead}
+        lastUpdated={lastUpdated}
+      />
+
+      {!hasEntries && (
+        <section className={styles.emptyState}>
+          <h2>No progress yet — start somewhere 🚀</h2>
+          <p>
+            CloudCaptain's Captain's Bridge reading mode tracks what you've read on each doc page.
+            Open any learning path or tool doc and use the <kbd>m</kbd> key or the{' '}
+            <em>"Mark section complete"</em> buttons to see your progress build up here.
+          </p>
+          <div className={styles.emptyActions}>
+            <Link className={`button button--primary button--lg`} to="/docs/learning-paths/welcome">
+              📚 Browse Learning Paths
+            </Link>
+            <Link className={`button button--secondary button--lg`} to="/docs/tools/docker/">
+              🐳 Start with Docker
+            </Link>
+          </div>
+          <p className={styles.emptyHint}>
+            Want to see what this page looks like populated? Use <strong>Seed demo data</strong>{' '}
+            below.
+          </p>
+        </section>
+      )}
+
+      <ProgressByTool allDocs={allDocs} entries={entries} />
+
+      <ProgressControls onChange={refresh} hasEntries={hasEntries} />
+    </main>
+  );
+}
+
+export default function ProgressPage(): JSX.Element {
+  return (
+    <Layout
+      title="Your Progress"
+      description="Track your cloud, DevOps, and AI-ops learning progress across all CloudCaptain docs. Privately stored in your browser.">
+      <BrowserOnly
+        fallback={
+          <main className={styles.page}>
+            <section className={styles.hero}>
+              <h1 className={styles.heroTitle}>📖 Your Progress</h1>
+              <p className={styles.heroSubtitle}>Loading…</p>
+            </section>
+          </main>
+        }>
+        {() => <ProgressPageInner />}
+      </BrowserOnly>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a top-level **`/progress`** dashboard and a **"Resume Reading" widget** on the homepage, both powered by the same localStorage data that Captain's Bridge writes when users mark sections complete.

Stacked on top of PR #41 (`feature/captains-bridge-reader`). Targets that branch as its base, so this PR's diff reads as the pure Progress feature — no Bridge noise. When #41 merges to main, retarget this PR's base to main (GitHub offers one click) and no rebase is needed.

## What this ships

### `/progress` page

- **Hero** — four stat cards: sections read, pages touched, pages complete, last active (relative + absolute timestamp).
- **By Category** — expandable groups for every learning path, tool, and cloud provider detected in the doc tree. Each group shows a dual progress bar (touched vs complete). Click to reveal every doc with status dot `○` / `◐` / `●`, title, and `N/M` counter.
- **Empty state** — clean CTA block when no progress exists, with links to DevOps path + Docker start.
- **Manage** — four control cards:
  - **⬇ Export** — downloads `cloudcaptain-progress-YYYY-MM-DD.json`
  - **⬆ Import** — merge or replace from a previously exported file
  - **🪄 Seed demo data** — fills 8 sample entries spread over the last 10 days for demos / screenshots; reversible via "Remove demo data"
  - **↻ Reset** — requires user to type `DELETE` to confirm
- Live updates via `cc-bridge-read-change` (same-tab) and `storage` (cross-tab) events.
- Footer link and new navbar link `📖 Progress` for discoverability.

### Homepage Resume Reading widget

- **`⚓ CAPTAIN'S LOG — Resume where you left off`** card, slotted between the hero and stats sections.
- Top 3 in-progress docs (`readCount > 0 && !isComplete`), sorted by most-recently-updated.
- Each row: title, `N / M` progress, relative time (`2h ago`), animated bar, doc path, `Continue →`.
- Renders **nothing** when there's no partial progress, so first-time visitors see an unchanged hero+stats flow.
- Wrapped in `BrowserOnly` — SSR is unaffected.

## Architecture

```
localStorage  (written by Bridge's useReadProgress)
  cloudcaptain.bridge.read./docs/tools/docker/fundamentals = {
    readSections: ["what-is-docker", "containers-vs-vms"],
    totalSections: 8,
    lastUpdated: 1713028347000
  }
        │
        ▼
  getAllReadEntries()           ←  readProgress.ts (duplicates Bridge contract)
        │
        ▼
  useAllDocsData()              ←  Docusaurus plugin-content-docs client API
  (full doc tree + titles)
        │
        ▼
  classifyDoc(pathname)         ←  groupDocs.ts (regex → category + icon)
        │
        ▼
  ┌────────────────────┬────────────────────────┐
  │  /progress         │  homepage widget       │
  │  ProgressHero      │  ResumeReadingWidget   │
  │  ProgressByTool    │                        │
  │  ProgressControls  │                        │
  └────────────────────┴────────────────────────┘
```

### Files added

```
website/src/pages/progress.tsx                                 (top-level page, SSR-safe)
website/src/components/Progress/
  ProgressHero.tsx              (four stat cards)
  ProgressByTool.tsx            (expandable category groups + dual progress bars)
  ProgressControls.tsx          (export / import / seed / reset, typed DELETE)
  ResumeReadingWidget.tsx       (homepage "Captain's Log" card)
  readProgress.ts               (localStorage reader / writer / export / import)
  groupDocs.ts                  (pathname → category matcher, ordered)
  seedDemo.ts                   (8 synthetic entries, reversible)
  styles.module.css             (dashboard styles)
  resumeWidget.module.css       (homepage widget styles)

website/src/pages/index.tsx     (wires BrowserOnly<ResumeReadingWidget />)
website/docusaurus.config.ts    (navbar + footer links)
```

### Design notes

- **Client-only.** No backend. No new npm dependencies. Everything runs in the browser.
- **Privacy first.** Progress stays in localStorage; the page surfaces this in a footer note and on the Reset card. Export provides user-owned backup; there's no telemetry.
- **SSR safe.** Every component that touches `localStorage` is gated by `BrowserOnly` or checks `typeof localStorage`. A minimal SSR skeleton renders on first paint and the real dashboard hydrates client-side.
- **Schema contract with Bridge.** `readProgress.ts` duplicates the 20-line localStorage helper that lives inside the Bridge feature (`useReadProgress.getAllReadEntries`). This duplication is intentional — it keeps the two features decoupled at the source code level but honours the same `cloudcaptain.bridge.read.{pathname}` key schema at the data level. Refactor into a shared module is easy once both PRs merge.
- **Category grouping is centralized.** `groupDocs.ts` holds the regex-to-category mapping with display icons and sort order — one file to update when a new tool section is added.
- **Demo seed is reversible.** Seeded keys are tracked in `cloudcaptain.bridge.demo-seed`; `unseedDemoProgress()` removes only those keys. Real user progress is never clobbered (seeder refuses to overwrite entries with non-zero `readCount`).

## Test plan

- [ ] `npm run build` in `website/` passes — no new warnings from this branch
- [ ] Navigate to `/progress`
  - [ ] Empty state renders with CTA block when localStorage is clean
  - [ ] Click `🪄 Seed demo data` — hero stats + groups populate instantly, 8 entries across Docker/K8s/Terraform/Linux/Git/DevOps
  - [ ] Expand any group — every doc appears with correct status dot
  - [ ] Click any doc link — navigates
- [ ] Complete a real section via Bridge's `m` key on a tool page → dashboard live-updates without refresh
- [ ] Open site in second tab, complete a section there → first tab's dashboard updates via `storage` event
- [ ] `⬇ Export` — downloads valid JSON (version:1, entries map)
- [ ] `⬆ Import → Merge` — adds entries without clobbering
- [ ] `⬆ Import → Replace all` — wipes then imports
- [ ] `↻ Reset` — requires typed `DELETE` confirmation; clears localStorage
- [ ] `🪄 Seed demo data` → `Remove demo data` — clean round-trip
- [ ] Homepage — with progress seeded, "Captain's Log" card appears between hero and stats
  - [ ] Shows top 3 in-progress docs
  - [ ] Progress bars match stored `readCount / totalSections`
  - [ ] "View all progress →" → `/progress`
  - [ ] Each row navigates to the doc
- [ ] Homepage — with progress cleared, widget does NOT render (clean hero+stats flow)
- [ ] Navbar `📖 Progress` link visible and routes correctly
- [ ] Footer `📖 Your Progress` link routes correctly
- [ ] Mobile viewport (< 600px) — all three views (dashboard, widget, controls) remain usable

## Not in this PR

- Calendar heatmap visualization (Phase 2).
- Cross-device sync (requires user accounts — explicitly out of scope).
- Learning-path grouping from `careerPaths.json` (different semantic model; defer).