### PR TITLE
Add visitor analytics (daily/weekly/total) with a README trend graph

### DIFF
--- a/.github/stats/chart-dark.svg
+++ b/.github/stats/chart-dark.svg
@@ -1,0 +1,4 @@
+<svg width="800" height="220" viewBox="0 0 800 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="No visitor data yet">
+  <rect width="800" height="220" fill="#0A1628" rx="8"/>
+  <text x="400" y="110" font-family="monospace" font-size="13" fill="#94A3B8" text-anchor="middle">No visitor data yet &#8212; GoatCounter setup pending</text>
+</svg>

--- a/.github/stats/chart-light.svg
+++ b/.github/stats/chart-light.svg
@@ -1,0 +1,4 @@
+<svg width="800" height="220" viewBox="0 0 800 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="No visitor data yet">
+  <rect width="800" height="220" fill="#FFFFFF" rx="8"/>
+  <text x="400" y="110" font-family="monospace" font-size="13" fill="#475569" text-anchor="middle">No visitor data yet &#8212; GoatCounter setup pending</text>
+</svg>

--- a/.github/stats/visitors-today.json
+++ b/.github/stats/visitors-today.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "visits today",
+  "message": "pending setup",
+  "color": "06B6D4"
+}

--- a/.github/stats/visitors-total.json
+++ b/.github/stats/visitors-total.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "visits total",
+  "message": "pending setup",
+  "color": "1E9BD7"
+}

--- a/.github/stats/visitors-week.json
+++ b/.github/stats/visitors-week.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "visits this week",
+  "message": "pending setup",
+  "color": "38BDF8"
+}

--- a/.github/workflows/visitor-stats.yml
+++ b/.github/workflows/visitor-stats.yml
@@ -1,0 +1,42 @@
+name: Update Visitor Stats
+
+on:
+  schedule:
+    - cron: '15 0 * * *' # daily at 00:15 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: visitor-stats
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    if: github.repository == 'nomadicmehul/CloudCaptain'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Fetch stats and regenerate chart + badges
+        env:
+          GOATCOUNTER_SITE_CODE: ${{ secrets.GOATCOUNTER_SITE_CODE }}
+          GOATCOUNTER_API_TOKEN: ${{ secrets.GOATCOUNTER_API_TOKEN }}
+        run: node scripts/update-visitor-stats.mjs
+
+      - name: Commit updated stats
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/stats
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update: visitor stats [skip ci]"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -149,6 +149,20 @@ CloudCaptain/
   .github/workflows/          # Deploy, PR checks, PR preview deploys
 ```
 
+## 📊 Site Traffic
+
+<div align="center">
+  <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/nomadicmehul/CloudCaptain/main/.github/stats/visitors-total.json" alt="Total visits" />
+  <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/nomadicmehul/CloudCaptain/main/.github/stats/visitors-week.json" alt="Visits this week" />
+  <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/nomadicmehul/CloudCaptain/main/.github/stats/visitors-today.json" alt="Visits today" />
+
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./.github/stats/chart-dark.svg">
+    <img src="./.github/stats/chart-light.svg" width="800" alt="Visitor traffic over the last 90 days" />
+  </picture>
+  <p><em>Updated daily via <a href="https://www.goatcounter.com">GoatCounter</a> — privacy-friendly, no cookies, no tracking of individuals.</em></p>
+</div>
+
 ## ⭐ Support the Project
 
 If CloudCaptain helped you learn something, prepare for an interview, or pass a certification — **[star the repo](https://github.com/nomadicmehul/CloudCaptain)**. It takes 2 seconds and genuinely helps other engineers discover a free alternative to paid courses.

--- a/scripts/update-visitor-stats.mjs
+++ b/scripts/update-visitor-stats.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Pulls visit counts from GoatCounter and regenerates the badges + line
+// chart that the README embeds. Run daily by .github/workflows/visitor-stats.yml.
+import {mkdir, writeFile} from 'node:fs/promises';
+import path from 'node:path';
+
+const SITE_CODE = process.env.GOATCOUNTER_SITE_CODE;
+const API_TOKEN = process.env.GOATCOUNTER_API_TOKEN;
+
+if (!SITE_CODE || !API_TOKEN) {
+  // Not configured yet (see issue #53) — skip instead of failing so the
+  // scheduled workflow doesn't show as a red X every day until it's set up.
+  console.warn(
+    'GOATCOUNTER_SITE_CODE / GOATCOUNTER_API_TOKEN not set — skipping visitor stats update.',
+  );
+  process.exit(0);
+}
+
+const API_BASE = `https://${SITE_CODE}.goatcounter.com/api/v0`;
+const CHART_WINDOW_DAYS = 90;
+const OUT_DIR = path.join(process.cwd(), '.github', 'stats');
+
+const BRAND = {
+  line: '#1E9BD7',
+  navy: '#0A1628',
+  panelDark: '#1B2A4A',
+  panelLight: '#E2E8F0',
+};
+
+async function fetchTotal(start, end) {
+  const url = new URL(`${API_BASE}/stats/total`);
+  url.searchParams.set('start', start.toISOString());
+  url.searchParams.set('end', end.toISOString());
+
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${API_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `GoatCounter API error ${res.status} on ${url}: ${await res.text()}`,
+    );
+  }
+
+  return res.json();
+}
+
+function badgeJson(label, message, color) {
+  return JSON.stringify({schemaVersion: 1, label, message, color}, null, 2) + '\n';
+}
+
+function buildChartSvg(points, theme) {
+  const width = 800;
+  const height = 220;
+  const padding = {top: 20, right: 20, bottom: 28, left: 20};
+  const plotWidth = width - padding.left - padding.right;
+  const plotHeight = height - padding.top - padding.bottom;
+
+  const isDark = theme === 'dark';
+  const bg = isDark ? BRAND.navy : '#FFFFFF';
+  const gridColor = isDark ? BRAND.panelDark : BRAND.panelLight;
+  const textColor = isDark ? '#94A3B8' : '#475569';
+  const fillTop = isDark ? 'rgba(30,155,215,0.35)' : 'rgba(30,155,215,0.25)';
+
+  if (points.length === 0) {
+    return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="No visitor data yet">
+  <rect width="${width}" height="${height}" fill="${bg}" rx="8"/>
+  <text x="${width / 2}" y="${height / 2}" font-family="monospace" font-size="13" fill="${textColor}" text-anchor="middle">No visitor data yet</text>
+</svg>`;
+  }
+
+  const max = Math.max(1, ...points.map((p) => p.count));
+  const stepX = points.length > 1 ? plotWidth / (points.length - 1) : 0;
+  const coords = points.map((p, i) => [
+    padding.left + i * stepX,
+    padding.top + plotHeight - (p.count / max) * plotHeight,
+  ]);
+
+  const linePath = coords
+    .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`)
+    .join(' ');
+  const floorY = padding.top + plotHeight;
+  const areaPath = `${linePath} L${coords.at(-1)[0].toFixed(1)},${floorY} L${coords[0][0].toFixed(1)},${floorY} Z`;
+
+  const firstLabel = points[0].day;
+  const lastLabel = points.at(-1).day;
+
+  return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Visitor traffic over the last ${points.length} days">
+  <rect width="${width}" height="${height}" fill="${bg}" rx="8"/>
+  <line x1="${padding.left}" y1="${floorY}" x2="${width - padding.right}" y2="${floorY}" stroke="${gridColor}" stroke-width="1"/>
+  <defs>
+    <linearGradient id="fill-${theme}" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="${fillTop}"/>
+      <stop offset="100%" stop-color="rgba(30,155,215,0)"/>
+    </linearGradient>
+  </defs>
+  <path d="${areaPath}" fill="url(#fill-${theme})" stroke="none"/>
+  <path d="${linePath}" fill="none" stroke="${BRAND.line}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+  <text x="${padding.left}" y="${height - 8}" font-family="monospace" font-size="11" fill="${textColor}">${firstLabel}</text>
+  <text x="${width - padding.right}" y="${height - 8}" font-family="monospace" font-size="11" fill="${textColor}" text-anchor="end">${lastLabel}</text>
+</svg>`;
+}
+
+const now = new Date();
+const windowStart = new Date(now.getTime() - CHART_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+// GoatCounter has no "all time" endpoint — a start date before any real
+// site can have launched stands in for one.
+const allTimeStart = new Date('2015-01-01T00:00:00Z');
+
+const [recent, allTime] = await Promise.all([
+  fetchTotal(windowStart, now),
+  fetchTotal(allTimeStart, now),
+]);
+
+// A stat bucket may report its count under `daily`, `weekly`, or `monthly`
+// depending on how GoatCounter auto-groups the requested range.
+const points = (recent.stats ?? []).map((s) => ({
+  day: (s.day ?? '').slice(5, 10) || '?',
+  count: s.daily ?? s.weekly ?? s.monthly ?? 0,
+}));
+
+const today = points.at(-1)?.count ?? 0;
+const thisWeek = points.slice(-7).reduce((sum, p) => sum + p.count, 0);
+const totalAllTime = allTime.total ?? 0;
+
+await mkdir(OUT_DIR, {recursive: true});
+
+await Promise.all([
+  writeFile(
+    path.join(OUT_DIR, 'visitors-total.json'),
+    badgeJson('visits total', totalAllTime.toLocaleString('en-US'), '1E9BD7'),
+  ),
+  writeFile(
+    path.join(OUT_DIR, 'visitors-week.json'),
+    badgeJson('visits this week', thisWeek.toLocaleString('en-US'), '38BDF8'),
+  ),
+  writeFile(
+    path.join(OUT_DIR, 'visitors-today.json'),
+    badgeJson('visits today', today.toLocaleString('en-US'), '06B6D4'),
+  ),
+  writeFile(path.join(OUT_DIR, 'chart-light.svg'), buildChartSvg(points, 'light')),
+  writeFile(path.join(OUT_DIR, 'chart-dark.svg'), buildChartSvg(points, 'dark')),
+]);
+
+console.log(
+  `Updated visitor stats: total=${totalAllTime} week=${thisWeek} today=${today} chartPoints=${points.length}`,
+);

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -23,14 +23,13 @@ const config: Config = {
   },
 
   // Visitor analytics via GoatCounter (free, privacy-friendly, no cookie banner needed).
-  // Sign up at https://www.goatcounter.com, then uncomment and set your site code below.
-  // scripts: [
-  //   {
-  //     src: 'https://gc.zgo.at/count.js',
-  //     async: true,
-  //     'data-goatcounter': 'https://YOUR-SITE-CODE.goatcounter.com/count',
-  //   },
-  // ],
+  scripts: [
+    {
+      src: 'https://gc.zgo.at/count.js',
+      async: true,
+      'data-goatcounter': 'https://cloudcaptain.goatcounter.com/count',
+    },
+  ],
 
   headTags: [
     // Preconnect to Google Fonts for faster font loading

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -22,6 +22,16 @@ const config: Config = {
     locales: ['en'],
   },
 
+  // Visitor analytics via GoatCounter (free, privacy-friendly, no cookie banner needed).
+  // Sign up at https://www.goatcounter.com, then uncomment and set your site code below.
+  // scripts: [
+  //   {
+  //     src: 'https://gc.zgo.at/count.js',
+  //     async: true,
+  //     'data-goatcounter': 'https://YOUR-SITE-CODE.goatcounter.com/count',
+  //   },
+  // ],
+
   headTags: [
     // Preconnect to Google Fonts for faster font loading
     {


### PR DESCRIPTION
Closes #53

## Summary
- Adds `scripts/update-visitor-stats.mjs`, which pulls total/weekly/daily visit counts from the GoatCounter API and generates a light+dark SVG trend chart plus shields.io badge JSON files.
- Adds `.github/workflows/visitor-stats.yml`, a scheduled Action (daily at 00:15 UTC, plus manual dispatch) that runs the script and commits the regenerated files. It skips gracefully (no failure) if the GoatCounter secrets aren't configured.
- Adds a "📊 Site Traffic" section to `README.md` with the total/week/today badges and the trend chart (theme-aware via `<picture>`).
- Enables the GoatCounter tracking script in `website/docusaurus.config.ts`, pointed at `cloudcaptain.goatcounter.com`.
- `GOATCOUNTER_SITE_CODE` and `GOATCOUNTER_API_TOKEN` repo secrets are already configured.

## Test plan
- [x] `npm run build` passes in `website/`
- [x] Verified the GoatCounter `<script>` tag renders in the built `index.html`
- [x] `node --check` on the stats script; verified it exits cleanly (warn + exit 0) when secrets are missing
- [x] After merge/deploy, let a day of traffic accumulate, then manually run the "Update Visitor Stats" workflow and confirm the README badges/chart populate with real numbers